### PR TITLE
Feature/simplify initialization

### DIFF
--- a/Examples/Hello.c
+++ b/Examples/Hello.c
@@ -62,7 +62,7 @@ static void sayHello(const Hello *self) {
  */
 static void initialize(Class *clazz) {
 
-	HelloInterface *hello = (HelloInterface *) clazz->def->interface;
+	HelloInterface *hello = (HelloInterface *) clazz->interface;
 
 	hello->helloWithGreeting = helloWithGreeting;
 	hello->initWithGreeting = initWithGreeting;
@@ -74,20 +74,22 @@ static void initialize(Class *clazz) {
  * @memberof Hello
  */
 Class *_Hello(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Hello";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Hello);
-		clazz.interfaceOffset = offsetof(Hello, interface);
-		clazz.interfaceSize = sizeof(HelloInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Hello",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Hello),
+			.interfaceOffset = offsetof(Hello, interface),
+			.interfaceSize = sizeof(HelloInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
-};
+	return clazz;
+}
 
 #undef _Class
 

--- a/README.md
+++ b/README.md
@@ -197,9 +197,9 @@ static void sayHello(const Hello *self) {
  */
 static void initialize(Class *clazz) {
  
-	((HelloInterface *) clazz->def->interface)->helloWithGreeting = helloWithGreeting;
-	((HelloInterface *) clazz->def->interface)->initWithGreeting = initWithGreeting;
-	((HelloInterface *) clazz->def->interface)->sayHello = sayHello;
+	((HelloInterface *) clazz->interface)->helloWithGreeting = helloWithGreeting;
+	((HelloInterface *) clazz->interface)->initWithGreeting = initWithGreeting;
+	((HelloInterface *) clazz->interface)->sayHello = sayHello;
 }
 
 /**
@@ -207,19 +207,21 @@ static void initialize(Class *clazz) {
  * @memberof Hello
  */
 Class *_Hello(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Hello";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Hello);
-		clazz.interfaceOffset = offsetof(Hello, interface);
-		clazz.interfaceSize = sizeof(HelloInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Hello",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Hello),
+			.interfaceOffset = offsetof(Hello, interface),
+			.interfaceSize = sizeof(HelloInterface),
+			.initialize = initialize
+		});
 	});
  
-	return &clazz;
+	return clazz;
 };
     
 #undef _Class
@@ -228,7 +230,7 @@ Class *_Hello(void) {
 Using a type
 ---
 ```c
-Hello *hello = $$(Hello, helloWithGreeting, NULL);
+Hello *hello = $(alloc(Hello), initWithGreeting, NULL);
 
 $(hello, sayHello);
 
@@ -261,8 +263,8 @@ Overriding a method
 To override a method, overwrite the function pointer from within your Class' `initialize` method.
 
 ```c
-    ((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-    ((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+    ((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+    ((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 ```
 
 Calling super

--- a/Sources/Objectively/Array.c
+++ b/Sources/Objectively/Array.c
@@ -446,30 +446,30 @@ static Array *sortedArray(const Array *self, Comparator comparator) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	((ObjectInterface *) clazz->def->interface)->description = description;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->description = description;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((ArrayInterface *) clazz->def->interface)->arrayWithArray = arrayWithArray;
-	((ArrayInterface *) clazz->def->interface)->arrayWithObjects = arrayWithObjects;
-	((ArrayInterface *) clazz->def->interface)->componentsJoinedByCharacters = componentsJoinedByCharacters;
-	((ArrayInterface *) clazz->def->interface)->componentsJoinedByString = componentsJoinedByString;
-	((ArrayInterface *) clazz->def->interface)->containsObject = containsObject;
-	((ArrayInterface *) clazz->def->interface)->enumerateObjects = enumerateObjects;
-	((ArrayInterface *) clazz->def->interface)->filteredArray = filteredArray;
-	((ArrayInterface *) clazz->def->interface)->findObject = findObject;
-	((ArrayInterface *) clazz->def->interface)->firstObject = firstObject;
-	((ArrayInterface *) clazz->def->interface)->indexOfObject = indexOfObject;
-	((ArrayInterface *) clazz->def->interface)->initWithArray = initWithArray;
-	((ArrayInterface *) clazz->def->interface)->initWithObjects = initWithObjects;
-	((ArrayInterface *) clazz->def->interface)->lastObject = lastObject;
-	((ArrayInterface *) clazz->def->interface)->mappedArray = mappedArray;
-	((ArrayInterface *) clazz->def->interface)->mutableCopy = mutableCopy;
-	((ArrayInterface *) clazz->def->interface)->objectAtIndex = objectAtIndex;
-	((ArrayInterface *) clazz->def->interface)->reduce = reduce;
-	((ArrayInterface *) clazz->def->interface)->sortedArray = sortedArray;
+	((ArrayInterface *) clazz->interface)->arrayWithArray = arrayWithArray;
+	((ArrayInterface *) clazz->interface)->arrayWithObjects = arrayWithObjects;
+	((ArrayInterface *) clazz->interface)->componentsJoinedByCharacters = componentsJoinedByCharacters;
+	((ArrayInterface *) clazz->interface)->componentsJoinedByString = componentsJoinedByString;
+	((ArrayInterface *) clazz->interface)->containsObject = containsObject;
+	((ArrayInterface *) clazz->interface)->enumerateObjects = enumerateObjects;
+	((ArrayInterface *) clazz->interface)->filteredArray = filteredArray;
+	((ArrayInterface *) clazz->interface)->findObject = findObject;
+	((ArrayInterface *) clazz->interface)->firstObject = firstObject;
+	((ArrayInterface *) clazz->interface)->indexOfObject = indexOfObject;
+	((ArrayInterface *) clazz->interface)->initWithArray = initWithArray;
+	((ArrayInterface *) clazz->interface)->initWithObjects = initWithObjects;
+	((ArrayInterface *) clazz->interface)->lastObject = lastObject;
+	((ArrayInterface *) clazz->interface)->mappedArray = mappedArray;
+	((ArrayInterface *) clazz->interface)->mutableCopy = mutableCopy;
+	((ArrayInterface *) clazz->interface)->objectAtIndex = objectAtIndex;
+	((ArrayInterface *) clazz->interface)->reduce = reduce;
+	((ArrayInterface *) clazz->interface)->sortedArray = sortedArray;
 }
 
 /**
@@ -477,19 +477,21 @@ static void initialize(Class *clazz) {
  * @memberof Array
  */
 Class *_Array(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Array";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Array);
-		clazz.interfaceOffset = offsetof(Array, interface);
-		clazz.interfaceSize = sizeof(ArrayInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Array",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Array),
+			.interfaceOffset = offsetof(Array, interface),
+			.interfaceSize = sizeof(ArrayInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Boole.c
+++ b/Sources/Objectively/Boole.c
@@ -101,12 +101,12 @@ static Boole *valueof(_Bool value) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->description = description;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->description = description;
 
-	((BooleInterface *) clazz->def->interface)->False = False;
-	((BooleInterface *) clazz->def->interface)->True = True;
-	((BooleInterface *) clazz->def->interface)->valueof = valueof;
+	((BooleInterface *) clazz->interface)->False = False;
+	((BooleInterface *) clazz->interface)->True = True;
+	((BooleInterface *) clazz->interface)->valueof = valueof;
 }
 
 /**
@@ -123,20 +123,22 @@ static void destroy(Class *clazz) {
  * @memberof Boole
  */
 Class *_Boole(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Boole";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Boole);
-		clazz.interfaceOffset = offsetof(Boole, interface);
-		clazz.interfaceSize = sizeof(BooleInterface);
-		clazz.initialize = initialize;
-		clazz.destroy = destroy;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Boole",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Boole),
+			.interfaceOffset = offsetof(Boole, interface),
+			.interfaceSize = sizeof(BooleInterface),
+			.initialize = initialize,
+			.destroy = destroy,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Class.h
+++ b/Sources/Objectively/Class.h
@@ -31,20 +31,11 @@
  * @brief Classes describe the state and behavior of an Objectively type.
  */
 
-/**
- * @brief Initialized Classes reflect this value as their first word.
- */
-#define CLASS_MAGIC 0xabcdef
-
 typedef struct ClassDef ClassDef;
 typedef struct Class Class;
 
 /**
- * @brief Classes describe the state and behavior of an Objectively type.
- * @details Classes are the bridge between Objects and their interfaces. They provide an entry
- * point to the framework via the library function <code>_alloc</code>.
- * @details Each Class describes a type and initializes an interface. Each instance of that type
- * will reference the Class and, in turn, its interface.
+ * @brief ClassDefs are passed to `_initialize` via an _archetype_ to initialize a Class.
  * @ingroup Core
  */
 struct ClassDef {
@@ -103,6 +94,9 @@ struct ClassDef {
  */
 struct Class {
 
+	/**
+	 * @brief The Class definition.
+	 */
 	ClassDef def;
 
 	/**

--- a/Sources/Objectively/Class.h
+++ b/Sources/Objectively/Class.h
@@ -47,17 +47,7 @@ typedef struct Class Class;
  * will reference the Class and, in turn, its interface.
  * @ingroup Core
  */
-struct Class {
-
-	/**
-	 * @brief Initialized Classes will have `CLASS_MAGIC`.
-	 */
-	volatile int magic;
-
-	/**
-	 * @brief The dynamically allocated Class definition.
-	 */
-	ClassDef *def;
+struct ClassDef {
 
 	/**
 	 * @brief The Class destructor (optional).
@@ -72,8 +62,8 @@ struct Class {
 	 * for populating the Class' `interface` with valid method implementations:
 	 * ```
 	 * static void initialize(Class *clazz) {
-	 *     ((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	 *     ((FooInterface *) clazz->def->interface)->bar = bar;
+	 *     ((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	 *     ((FooInterface *) clazz->interface)->bar = bar;
 	 * }
 	 * ```
 	 * @remarks Each Class' `interface` is copied from its superclass before this initializer is
@@ -111,12 +101,9 @@ struct Class {
 /**
  * @brief The runtime representation of a Class.
  */
-struct ClassDef {
+struct Class {
 
-	/**
-	 * @brief A dynamically allocated copy of the Class descriptor.
-	 */
-	Class descriptor;
+	ClassDef def;
 
 	/**
 	 * @brief The interface of the Class.
@@ -126,7 +113,7 @@ struct ClassDef {
 	/**
 	 * @brief Provides chaining of initialized Classes.
 	 */
-	ClassDef *next;
+	Class *next;
 };
 
 /**
@@ -134,7 +121,7 @@ struct ClassDef {
  * @param clazz The Class descriptor.
  * @return The initialized Class.
  */
-OBJECTIVELY_EXPORT Class* _initialize(Class *clazz);
+OBJECTIVELY_EXPORT Class* _initialize(const ClassDef *clazz);
 
 /**
  * @brief Instantiate a type through the given Class.
@@ -194,7 +181,7 @@ OBJECTIVELY_EXPORT size_t _pageSize;
  * @brief Resolve the typed interface of a Class.
  */
 #define interfaceof(type, clazz) \
-	((type##Interface *) (clazz)->def->interface)
+	((type##Interface *) (clazz)->interface)
 
 /**
  * @brief Invoke an instance method.
@@ -210,7 +197,6 @@ OBJECTIVELY_EXPORT size_t _pageSize;
  */
 #define $$(type, method, ...) \
 	({ \
-		_initialize(_##type()); \
 		interfaceof(type, _##type())->method(__VA_ARGS__); \
 	})
 
@@ -218,4 +204,4 @@ OBJECTIVELY_EXPORT size_t _pageSize;
  * @brief Invoke a Superclass instance method.
  */
 #define super(type, obj, method, ...) \
-	interfaceof(type, _Class()->superclass)->method(cast(type, obj), ## __VA_ARGS__)
+	interfaceof(type, _Class()->def.superclass)->method(cast(type, obj), ## __VA_ARGS__)

--- a/Sources/Objectively/Condition.c
+++ b/Sources/Objectively/Condition.c
@@ -125,13 +125,13 @@ static _Bool waitUntilDate(Condition *self, const Date *date) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((ConditionInterface *) clazz->def->interface)->broadcast = broadcast;
-	((ConditionInterface *) clazz->def->interface)->init = init;
-	((ConditionInterface *) clazz->def->interface)->signal = _signal;
-	((ConditionInterface *) clazz->def->interface)->wait = _wait;
-	((ConditionInterface *) clazz->def->interface)->waitUntilDate = waitUntilDate;
+	((ConditionInterface *) clazz->interface)->broadcast = broadcast;
+	((ConditionInterface *) clazz->interface)->init = init;
+	((ConditionInterface *) clazz->interface)->signal = _signal;
+	((ConditionInterface *) clazz->interface)->wait = _wait;
+	((ConditionInterface *) clazz->interface)->waitUntilDate = waitUntilDate;
 }
 
 /**
@@ -139,19 +139,21 @@ static void initialize(Class *clazz) {
  * @memberof Condition
  */
 Class *_Condition(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Condition";
-		clazz.superclass = _Lock();
-		clazz.instanceSize = sizeof(Condition);
-		clazz.interfaceOffset = offsetof(Condition, interface);
-		clazz.interfaceSize = sizeof(ConditionInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Condition",
+			.superclass = _Lock(),
+			.instanceSize = sizeof(Condition),
+			.interfaceOffset = offsetof(Condition, interface),
+			.interfaceSize = sizeof(ConditionInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Data.c
+++ b/Sources/Objectively/Data.c
@@ -259,21 +259,21 @@ static _Bool writeToFile(const Data *self, const char *path) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((DataInterface *) clazz->def->interface)->dataWithBytes = dataWithBytes;
-	((DataInterface *) clazz->def->interface)->dataWithConstMemory = dataWithConstMemory;
-	((DataInterface *) clazz->def->interface)->dataWithContentsOfFile = dataWithContentsOfFile;
-	((DataInterface *) clazz->def->interface)->dataWithMemory = dataWithMemory;
-	((DataInterface *) clazz->def->interface)->initWithBytes = initWithBytes;
-	((DataInterface *) clazz->def->interface)->initWithConstMemory = initWithConstMemory;
-	((DataInterface *) clazz->def->interface)->initWithContentsOfFile = initWithContentsOfFile;
-	((DataInterface *) clazz->def->interface)->initWithMemory = initWithMemory;
-	((DataInterface *) clazz->def->interface)->mutableCopy = mutableCopy;
-	((DataInterface *) clazz->def->interface)->writeToFile = writeToFile;
+	((DataInterface *) clazz->interface)->dataWithBytes = dataWithBytes;
+	((DataInterface *) clazz->interface)->dataWithConstMemory = dataWithConstMemory;
+	((DataInterface *) clazz->interface)->dataWithContentsOfFile = dataWithContentsOfFile;
+	((DataInterface *) clazz->interface)->dataWithMemory = dataWithMemory;
+	((DataInterface *) clazz->interface)->initWithBytes = initWithBytes;
+	((DataInterface *) clazz->interface)->initWithConstMemory = initWithConstMemory;
+	((DataInterface *) clazz->interface)->initWithContentsOfFile = initWithContentsOfFile;
+	((DataInterface *) clazz->interface)->initWithMemory = initWithMemory;
+	((DataInterface *) clazz->interface)->mutableCopy = mutableCopy;
+	((DataInterface *) clazz->interface)->writeToFile = writeToFile;
 }
 
 /**
@@ -281,19 +281,21 @@ static void initialize(Class *clazz) {
  * @memberof Data
  */
 Class *_Data(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Data";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Data);
-		clazz.interfaceOffset = offsetof(Data, interface);
-		clazz.interfaceSize = sizeof(DataInterface);
-		clazz.initialize = initialize;
-	});;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Data",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Data),
+			.interfaceOffset = offsetof(Data, interface),
+			.interfaceSize = sizeof(DataInterface),
+			.initialize = initialize,
+		});
+	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Date.c
+++ b/Sources/Objectively/Date.c
@@ -202,17 +202,17 @@ static Time timeSinceTime(const Date *self, const Time *time) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((DateInterface *) clazz->def->interface)->compareTo = compareTo;
-	((DateInterface *) clazz->def->interface)->date = date;
-	((DateInterface *) clazz->def->interface)->dateWithTimeSinceNow = dateWithTimeSinceNow;
-	((DateInterface *) clazz->def->interface)->init = init;
-	((DateInterface *) clazz->def->interface)->initWithTime = initWithTime;
-	((DateInterface *) clazz->def->interface)->timeSinceDate = timeSinceDate;
-	((DateInterface *) clazz->def->interface)->timeSinceNow = timeSinceNow;
-	((DateInterface *) clazz->def->interface)->timeSinceTime = timeSinceTime;
+	((DateInterface *) clazz->interface)->compareTo = compareTo;
+	((DateInterface *) clazz->interface)->date = date;
+	((DateInterface *) clazz->interface)->dateWithTimeSinceNow = dateWithTimeSinceNow;
+	((DateInterface *) clazz->interface)->init = init;
+	((DateInterface *) clazz->interface)->initWithTime = initWithTime;
+	((DateInterface *) clazz->interface)->timeSinceDate = timeSinceDate;
+	((DateInterface *) clazz->interface)->timeSinceNow = timeSinceNow;
+	((DateInterface *) clazz->interface)->timeSinceTime = timeSinceTime;
 }
 
 /**
@@ -220,19 +220,21 @@ static void initialize(Class *clazz) {
  * @memberof Date
  */
 Class *_Date(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Date";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Date);
-		clazz.interfaceOffset = offsetof(Date, interface);
-		clazz.interfaceSize = sizeof(DateInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Date",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Date),
+			.interfaceOffset = offsetof(Date, interface),
+			.interfaceSize = sizeof(DateInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/DateFormatter.c
+++ b/Sources/Objectively/DateFormatter.c
@@ -117,10 +117,10 @@ static String *stringFromDate(const DateFormatter *self, const Date *date) {
  */
 static void initialize(Class *clazz) {
 
-	((DateFormatterInterface *) clazz->def->interface)->dateFromCharacters = dateFromCharacters;
-	((DateFormatterInterface *) clazz->def->interface)->dateFromString = dateFromString;
-	((DateFormatterInterface *) clazz->def->interface)->initWithFormat = initWithFormat;
-	((DateFormatterInterface *) clazz->def->interface)->stringFromDate = stringFromDate;
+	((DateFormatterInterface *) clazz->interface)->dateFromCharacters = dateFromCharacters;
+	((DateFormatterInterface *) clazz->interface)->dateFromString = dateFromString;
+	((DateFormatterInterface *) clazz->interface)->initWithFormat = initWithFormat;
+	((DateFormatterInterface *) clazz->interface)->stringFromDate = stringFromDate;
 
 	tzset();
 }
@@ -130,19 +130,21 @@ static void initialize(Class *clazz) {
  * @memberof DateFormatter
  */
 Class *_DateFormatter(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "DateFormatter";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(DateFormatter);
-		clazz.interfaceOffset = offsetof(DateFormatter, interface);
-		clazz.interfaceSize = sizeof(DateFormatterInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "DateFormatter",
+			.superclass = _Object(),
+			.instanceSize = sizeof(DateFormatter),
+			.interfaceOffset = offsetof(DateFormatter, interface),
+			.interfaceSize = sizeof(DateFormatterInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Dictionary.c
+++ b/Sources/Objectively/Dictionary.c
@@ -419,25 +419,25 @@ static ident objectForKeyPath(const Dictionary *self, const char *path) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	((ObjectInterface *) clazz->def->interface)->description = description;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->description = description;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((DictionaryInterface *) clazz->def->interface)->allKeys = allKeys;
-	((DictionaryInterface *) clazz->def->interface)->allObjects = allObjects;
-	((DictionaryInterface *) clazz->def->interface)->containsKey = containsKey;
-	((DictionaryInterface *) clazz->def->interface)->containsKeyPath = containsKeyPath;
-	((DictionaryInterface *) clazz->def->interface)->dictionaryWithDictionary = dictionaryWithDictionary;
-	((DictionaryInterface *) clazz->def->interface)->dictionaryWithObjectsAndKeys = dictionaryWithObjectsAndKeys;
-	((DictionaryInterface *) clazz->def->interface)->enumerateObjectsAndKeys = enumerateObjectsAndKeys;
-	((DictionaryInterface *) clazz->def->interface)->filterObjectsAndKeys = filterObjectsAndKeys;
-	((DictionaryInterface *) clazz->def->interface)->initWithDictionary = initWithDictionary;
-	((DictionaryInterface *) clazz->def->interface)->initWithObjectsAndKeys = initWithObjectsAndKeys;
-	((DictionaryInterface *) clazz->def->interface)->mutableCopy = mutableCopy;
-	((DictionaryInterface *) clazz->def->interface)->objectForKey = objectForKey;
-	((DictionaryInterface *) clazz->def->interface)->objectForKeyPath = objectForKeyPath;
+	((DictionaryInterface *) clazz->interface)->allKeys = allKeys;
+	((DictionaryInterface *) clazz->interface)->allObjects = allObjects;
+	((DictionaryInterface *) clazz->interface)->containsKey = containsKey;
+	((DictionaryInterface *) clazz->interface)->containsKeyPath = containsKeyPath;
+	((DictionaryInterface *) clazz->interface)->dictionaryWithDictionary = dictionaryWithDictionary;
+	((DictionaryInterface *) clazz->interface)->dictionaryWithObjectsAndKeys = dictionaryWithObjectsAndKeys;
+	((DictionaryInterface *) clazz->interface)->enumerateObjectsAndKeys = enumerateObjectsAndKeys;
+	((DictionaryInterface *) clazz->interface)->filterObjectsAndKeys = filterObjectsAndKeys;
+	((DictionaryInterface *) clazz->interface)->initWithDictionary = initWithDictionary;
+	((DictionaryInterface *) clazz->interface)->initWithObjectsAndKeys = initWithObjectsAndKeys;
+	((DictionaryInterface *) clazz->interface)->mutableCopy = mutableCopy;
+	((DictionaryInterface *) clazz->interface)->objectForKey = objectForKey;
+	((DictionaryInterface *) clazz->interface)->objectForKeyPath = objectForKeyPath;
 }
 
 /**
@@ -445,19 +445,21 @@ static void initialize(Class *clazz) {
  * @memberof Dictionary
  */
 Class *_Dictionary(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Dictionary";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Dictionary);
-		clazz.interfaceOffset = offsetof(Dictionary, interface);
-		clazz.interfaceSize = sizeof(DictionaryInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Dictionary",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Dictionary),
+			.interfaceOffset = offsetof(Dictionary, interface),
+			.interfaceSize = sizeof(DictionaryInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Error.c
+++ b/Sources/Objectively/Error.c
@@ -150,13 +150,13 @@ static Error *initWithDomain(Error *self, String *domain, int code, String *mess
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	((ObjectInterface *) clazz->def->interface)->description = description;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->description = description;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((ErrorInterface *) clazz->def->interface)->initWithDomain = initWithDomain;
+	((ErrorInterface *) clazz->interface)->initWithDomain = initWithDomain;
 }
 
 /**
@@ -164,19 +164,21 @@ static void initialize(Class *clazz) {
  * @memberof Error
  */
 Class *_Error(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Error";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Error);
-		clazz.interfaceOffset = offsetof(Error, interface);
-		clazz.interfaceSize = sizeof(ErrorInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Error",
+			.superclass = _Object(),
+			.instanceSize = sizeof(_Error),
+			.interfaceOffset = offsetof(Error, interface),
+			.interfaceSize = sizeof(ErrorInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/IndexPath.c
+++ b/Sources/Objectively/IndexPath.c
@@ -162,15 +162,15 @@ static IndexPath *initWithIndexes(IndexPath *self, size_t *indexes, size_t lengt
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	((ObjectInterface *) clazz->def->interface)->description = description;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->description = description;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((IndexPathInterface *) clazz->def->interface)->indexAtPosition = indexAtPosition;
-	((IndexPathInterface *) clazz->def->interface)->initWithIndex = initWithIndex;
-	((IndexPathInterface *) clazz->def->interface)->initWithIndexes = initWithIndexes;
+	((IndexPathInterface *) clazz->interface)->indexAtPosition = indexAtPosition;
+	((IndexPathInterface *) clazz->interface)->initWithIndex = initWithIndex;
+	((IndexPathInterface *) clazz->interface)->initWithIndexes = initWithIndexes;
 }
 
 /**
@@ -178,19 +178,21 @@ static void initialize(Class *clazz) {
  * @memberof IndexPath
  */
 Class *_IndexPath(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "IndexPath";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(IndexPath);
-		clazz.interfaceOffset = offsetof(IndexPath, interface);
-		clazz.interfaceSize = sizeof(IndexPathInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "IndexPath",
+			.superclass = _Object(),
+			.instanceSize = sizeof(IndexPath),
+			.interfaceOffset = offsetof(IndexPath, interface),
+			.interfaceSize = sizeof(IndexPathInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/IndexSet.c
+++ b/Sources/Objectively/IndexSet.c
@@ -200,15 +200,15 @@ static IndexSet *initWithIndexes(IndexSet *self, size_t *indexes, size_t count) 
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	((ObjectInterface *) clazz->def->interface)->description = description;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->description = description;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((IndexSetInterface *) clazz->def->interface)->containsIndex = containsIndex;
-	((IndexSetInterface *) clazz->def->interface)->initWithIndex = initWithIndex;
-	((IndexSetInterface *) clazz->def->interface)->initWithIndexes = initWithIndexes;
+	((IndexSetInterface *) clazz->interface)->containsIndex = containsIndex;
+	((IndexSetInterface *) clazz->interface)->initWithIndex = initWithIndex;
+	((IndexSetInterface *) clazz->interface)->initWithIndexes = initWithIndexes;
 }
 
 /**
@@ -216,19 +216,21 @@ static void initialize(Class *clazz) {
  * @memberof IndexSet
  */
 Class *_IndexSet(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "IndexSet";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(IndexSet);
-		clazz.interfaceOffset = offsetof(IndexSet, interface);
-		clazz.interfaceSize = sizeof(IndexSetInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "IndexSet",
+			.superclass = _Object(),
+			.instanceSize = sizeof(IndexSet),
+			.interfaceOffset = offsetof(IndexSet, interface),
+			.interfaceSize = sizeof(IndexSetInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/JSONPath.c
+++ b/Sources/Objectively/JSONPath.c
@@ -98,7 +98,7 @@ static ident objectForKeyPath(const ident root, const char *path) {
  */
 static void initialize(Class *clazz) {
 
-	((JSONPathInterface *) clazz->def->interface)->objectForKeyPath = objectForKeyPath;
+	((JSONPathInterface *) clazz->interface)->objectForKeyPath = objectForKeyPath;
 
 	_re = re("(.[^.\\[]+|\\[[0-9]+\\])", 0);
 }
@@ -116,20 +116,22 @@ static void destroy(Class *clazz) {
  * @memberof JSONPath
  */
 Class *_JSONPath(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "JSONPath";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(JSONPath);
-		clazz.interfaceOffset = offsetof(JSONPath, interface);
-		clazz.interfaceSize = sizeof(JSONPathInterface);
-		clazz.initialize = initialize;
-		clazz.destroy = destroy;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "JSONPath",
+			.superclass = _Object(),
+			.instanceSize = sizeof(JSONPath),
+			.interfaceOffset = offsetof(JSONPath, interface),
+			.interfaceSize = sizeof(JSONPathInterface),
+			.initialize = initialize,
+			.destroy = destroy,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/JSONSerialization.c
+++ b/Sources/Objectively/JSONSerialization.c
@@ -468,8 +468,8 @@ static ident objectFromData(const Data *data, int options) {
  */
 static void initialize(Class *clazz) {
 
-	((JSONSerializationInterface *) clazz->def->interface)->dataFromObject = dataFromObject;
-	((JSONSerializationInterface *) clazz->def->interface)->objectFromData = objectFromData;
+	((JSONSerializationInterface *) clazz->interface)->dataFromObject = dataFromObject;
+	((JSONSerializationInterface *) clazz->interface)->objectFromData = objectFromData;
 }
 
 /**
@@ -477,19 +477,21 @@ static void initialize(Class *clazz) {
  * @memberof JSONSerialization
  */
 Class *_JSONSerialization(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "JSONSerialization";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(JSONSerialization);
-		clazz.interfaceOffset = offsetof(JSONSerialization, interface);
-		clazz.interfaceSize = sizeof(JSONSerializationInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "JSONSerialization",
+			.superclass = _Object(),
+			.instanceSize = sizeof(JSONSerialization),
+			.interfaceOffset = offsetof(JSONSerialization, interface),
+			.interfaceSize = sizeof(JSONSerializationInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Lock.c
+++ b/Sources/Objectively/Lock.c
@@ -113,13 +113,13 @@ static void unlock(Lock *self) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((LockInterface *) clazz->def->interface)->init = init;
-	((LockInterface *) clazz->def->interface)->lock = lock;
-	((LockInterface *) clazz->def->interface)->tryLock = tryLock;
-	((LockInterface *) clazz->def->interface)->unlock = unlock;
+	((LockInterface *) clazz->interface)->init = init;
+	((LockInterface *) clazz->interface)->lock = lock;
+	((LockInterface *) clazz->interface)->tryLock = tryLock;
+	((LockInterface *) clazz->interface)->unlock = unlock;
 }
 
 /**
@@ -127,19 +127,21 @@ static void initialize(Class *clazz) {
  * @memberof Lock
  */
 Class *_Lock(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Lock";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Lock);
-		clazz.interfaceOffset = offsetof(Lock, interface);
-		clazz.interfaceSize = sizeof(LockInterface);
-		clazz.initialize = initialize;
-	});;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Lock",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Lock),
+			.interfaceOffset = offsetof(Lock, interface),
+			.interfaceSize = sizeof(LockInterface),
+			.initialize = initialize,
+		});
+	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Log.c
+++ b/Sources/Objectively/Log.c
@@ -255,19 +255,19 @@ static void warn(const Log *self, const char *fmt, ...) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((LogInterface *) clazz->def->interface)->debug = debug;
-	((LogInterface *) clazz->def->interface)->error = error;
-	((LogInterface *) clazz->def->interface)->fatal = fatal;
-	((LogInterface *) clazz->def->interface)->flush = flush;
-	((LogInterface *) clazz->def->interface)->info = info;
-	((LogInterface *) clazz->def->interface)->init = init;
-	((LogInterface *) clazz->def->interface)->initWithName = initWithName;
-	((LogInterface *) clazz->def->interface)->log = _log;
-	((LogInterface *) clazz->def->interface)->trace = trace;
-	((LogInterface *) clazz->def->interface)->sharedInstance = sharedInstance;
-	((LogInterface *) clazz->def->interface)->warn = warn;
+	((LogInterface *) clazz->interface)->debug = debug;
+	((LogInterface *) clazz->interface)->error = error;
+	((LogInterface *) clazz->interface)->fatal = fatal;
+	((LogInterface *) clazz->interface)->flush = flush;
+	((LogInterface *) clazz->interface)->info = info;
+	((LogInterface *) clazz->interface)->init = init;
+	((LogInterface *) clazz->interface)->initWithName = initWithName;
+	((LogInterface *) clazz->interface)->log = _log;
+	((LogInterface *) clazz->interface)->trace = trace;
+	((LogInterface *) clazz->interface)->sharedInstance = sharedInstance;
+	((LogInterface *) clazz->interface)->warn = warn;
 }
 
 /**
@@ -283,20 +283,22 @@ static void destroy(Class *clazz) {
  * @memberof Log
  */
 Class *_Log(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Log";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Log);
-		clazz.interfaceOffset = offsetof(Log, interface);
-		clazz.interfaceSize = sizeof(LogInterface);
-		clazz.initialize = initialize;
-		clazz.destroy = destroy;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Log",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Log),
+			.interfaceOffset = offsetof(Log, interface),
+			.interfaceSize = sizeof(LogInterface),
+			.initialize = initialize,
+			.destroy = destroy,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/MutableArray.c
+++ b/Sources/Objectively/MutableArray.c
@@ -327,24 +327,24 @@ static void sort(MutableArray *self, Comparator comparator) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->copy = copy;
 
-	((MutableArrayInterface *) clazz->def->interface)->addObject = addObject;
-	((MutableArrayInterface *) clazz->def->interface)->addObjects = addObjects;
-	((MutableArrayInterface *) clazz->def->interface)->addObjectsFromArray = addObjectsFromArray;
-	((MutableArrayInterface *) clazz->def->interface)->array = array;
-	((MutableArrayInterface *) clazz->def->interface)->arrayWithCapacity = arrayWithCapacity;
-	((MutableArrayInterface *) clazz->def->interface)->filter = filter;
-	((MutableArrayInterface *) clazz->def->interface)->init = init;
-	((MutableArrayInterface *) clazz->def->interface)->initWithCapacity = initWithCapacity;
-	((MutableArrayInterface *) clazz->def->interface)->insertObjectAtIndex = insertObjectAtIndex;
-	((MutableArrayInterface *) clazz->def->interface)->removeAllObjects = removeAllObjects;
-	((MutableArrayInterface *) clazz->def->interface)->removeAllObjectsWithEnumerator = removeAllObjectsWithEnumerator;
-	((MutableArrayInterface *) clazz->def->interface)->removeLastObject = removeLastObject;
-	((MutableArrayInterface *) clazz->def->interface)->removeObject = removeObject;
-	((MutableArrayInterface *) clazz->def->interface)->removeObjectAtIndex = removeObjectAtIndex;
-	((MutableArrayInterface *) clazz->def->interface)->setObjectAtIndex = setObjectAtIndex;
-	((MutableArrayInterface *) clazz->def->interface)->sort = sort;
+	((MutableArrayInterface *) clazz->interface)->addObject = addObject;
+	((MutableArrayInterface *) clazz->interface)->addObjects = addObjects;
+	((MutableArrayInterface *) clazz->interface)->addObjectsFromArray = addObjectsFromArray;
+	((MutableArrayInterface *) clazz->interface)->array = array;
+	((MutableArrayInterface *) clazz->interface)->arrayWithCapacity = arrayWithCapacity;
+	((MutableArrayInterface *) clazz->interface)->filter = filter;
+	((MutableArrayInterface *) clazz->interface)->init = init;
+	((MutableArrayInterface *) clazz->interface)->initWithCapacity = initWithCapacity;
+	((MutableArrayInterface *) clazz->interface)->insertObjectAtIndex = insertObjectAtIndex;
+	((MutableArrayInterface *) clazz->interface)->removeAllObjects = removeAllObjects;
+	((MutableArrayInterface *) clazz->interface)->removeAllObjectsWithEnumerator = removeAllObjectsWithEnumerator;
+	((MutableArrayInterface *) clazz->interface)->removeLastObject = removeLastObject;
+	((MutableArrayInterface *) clazz->interface)->removeObject = removeObject;
+	((MutableArrayInterface *) clazz->interface)->removeObjectAtIndex = removeObjectAtIndex;
+	((MutableArrayInterface *) clazz->interface)->setObjectAtIndex = setObjectAtIndex;
+	((MutableArrayInterface *) clazz->interface)->sort = sort;
 }
 
 /**
@@ -352,19 +352,21 @@ static void initialize(Class *clazz) {
  * @memberof MutableArray
  */
 Class *_MutableArray(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "MutableArray";
-		clazz.superclass = _Array();
-		clazz.instanceSize = sizeof(MutableArray);
-		clazz.interfaceOffset = offsetof(MutableArray, interface);
-		clazz.interfaceSize = sizeof(MutableArrayInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "MutableArray",
+			.superclass = _Array(),
+			.instanceSize = sizeof(MutableArray),
+			.interfaceOffset = offsetof(MutableArray, interface),
+			.interfaceSize = sizeof(MutableArrayInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/MutableData.c
+++ b/Sources/Objectively/MutableData.c
@@ -161,16 +161,16 @@ static void setLength(MutableData *self, size_t length) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->copy = copy;
 
-	((MutableDataInterface *) clazz->def->interface)->appendBytes = appendBytes;
-	((MutableDataInterface *) clazz->def->interface)->appendData = appendData;
-	((MutableDataInterface *) clazz->def->interface)->data = data;
-	((MutableDataInterface *) clazz->def->interface)->dataWithCapacity = dataWithCapacity;
-	((MutableDataInterface *) clazz->def->interface)->init = init;
-	((MutableDataInterface *) clazz->def->interface)->initWithCapacity = initWithCapacity;
-	((MutableDataInterface *) clazz->def->interface)->initWithData = initWithData;
-	((MutableDataInterface *) clazz->def->interface)->setLength = setLength;
+	((MutableDataInterface *) clazz->interface)->appendBytes = appendBytes;
+	((MutableDataInterface *) clazz->interface)->appendData = appendData;
+	((MutableDataInterface *) clazz->interface)->data = data;
+	((MutableDataInterface *) clazz->interface)->dataWithCapacity = dataWithCapacity;
+	((MutableDataInterface *) clazz->interface)->init = init;
+	((MutableDataInterface *) clazz->interface)->initWithCapacity = initWithCapacity;
+	((MutableDataInterface *) clazz->interface)->initWithData = initWithData;
+	((MutableDataInterface *) clazz->interface)->setLength = setLength;
 }
 
 /**
@@ -178,19 +178,21 @@ static void initialize(Class *clazz) {
  * @memberof MutableData
  */
 Class *_MutableData(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "MutableData";
-		clazz.superclass = _Data();
-		clazz.instanceSize = sizeof(MutableData);
-		clazz.interfaceOffset = offsetof(MutableData, interface);
-		clazz.interfaceSize = sizeof(MutableDataInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "MutableData",
+			.superclass = _Data(),
+			.instanceSize = sizeof(MutableData),
+			.interfaceOffset = offsetof(MutableData, interface),
+			.interfaceSize = sizeof(MutableDataInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/MutableDictionary.c
+++ b/Sources/Objectively/MutableDictionary.c
@@ -343,21 +343,21 @@ static void setObjectsForKeys(MutableDictionary *self, ...) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->copy = copy;
 
-	((MutableDictionaryInterface *) clazz->def->interface)->addEntriesFromDictionary = addEntriesFromDictionary;
-	((MutableDictionaryInterface *) clazz->def->interface)->dictionary = dictionary;
-	((MutableDictionaryInterface *) clazz->def->interface)->dictionaryWithCapacity = dictionaryWithCapacity;
-	((MutableDictionaryInterface *) clazz->def->interface)->init = init;
-	((MutableDictionaryInterface *) clazz->def->interface)->initWithCapacity = initWithCapacity;
-	((MutableDictionaryInterface *) clazz->def->interface)->removeAllObjects = removeAllObjects;
-	((MutableDictionaryInterface *) clazz->def->interface)->removeAllObjectsWithEnumerator = removeAllObjectsWithEnumerator;
-	((MutableDictionaryInterface *) clazz->def->interface)->removeObjectForKey = removeObjectForKey;
-	((MutableDictionaryInterface *) clazz->def->interface)->removeObjectForKeyPath = removeObjectForKeyPath;
-	((MutableDictionaryInterface *) clazz->def->interface)->setObjectForKey = setObjectForKey;
-	((MutableDictionaryInterface *) clazz->def->interface)->setObjectForKeyPath = setObjectForKeyPath;
-	((MutableDictionaryInterface *) clazz->def->interface)->setObjectsForKeyPaths = setObjectsForKeyPaths;
-	((MutableDictionaryInterface *) clazz->def->interface)->setObjectsForKeys = setObjectsForKeys;
+	((MutableDictionaryInterface *) clazz->interface)->addEntriesFromDictionary = addEntriesFromDictionary;
+	((MutableDictionaryInterface *) clazz->interface)->dictionary = dictionary;
+	((MutableDictionaryInterface *) clazz->interface)->dictionaryWithCapacity = dictionaryWithCapacity;
+	((MutableDictionaryInterface *) clazz->interface)->init = init;
+	((MutableDictionaryInterface *) clazz->interface)->initWithCapacity = initWithCapacity;
+	((MutableDictionaryInterface *) clazz->interface)->removeAllObjects = removeAllObjects;
+	((MutableDictionaryInterface *) clazz->interface)->removeAllObjectsWithEnumerator = removeAllObjectsWithEnumerator;
+	((MutableDictionaryInterface *) clazz->interface)->removeObjectForKey = removeObjectForKey;
+	((MutableDictionaryInterface *) clazz->interface)->removeObjectForKeyPath = removeObjectForKeyPath;
+	((MutableDictionaryInterface *) clazz->interface)->setObjectForKey = setObjectForKey;
+	((MutableDictionaryInterface *) clazz->interface)->setObjectForKeyPath = setObjectForKeyPath;
+	((MutableDictionaryInterface *) clazz->interface)->setObjectsForKeyPaths = setObjectsForKeyPaths;
+	((MutableDictionaryInterface *) clazz->interface)->setObjectsForKeys = setObjectsForKeys;
 }
 
 /**
@@ -365,19 +365,21 @@ static void initialize(Class *clazz) {
  * @memberof MutableDictionary
  */
 Class *_MutableDictionary(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "MutableDictionary";
-		clazz.superclass = _Dictionary();
-		clazz.instanceSize = sizeof(MutableDictionary);
-		clazz.interfaceOffset = offsetof(MutableDictionary, interface);
-		clazz.interfaceSize = sizeof(MutableDictionaryInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "MutableDictionary",
+			.superclass = _Dictionary(),
+			.instanceSize = sizeof(MutableDictionary),
+			.interfaceOffset = offsetof(MutableDictionary, interface),
+			.interfaceSize = sizeof(MutableDictionaryInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/MutableSet.c
+++ b/Sources/Objectively/MutableSet.c
@@ -273,18 +273,18 @@ static MutableSet *setWithCapacity(size_t capacity) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->copy = copy;
 
-	((MutableSetInterface *) clazz->def->interface)->addObject = addObject;
-	((MutableSetInterface *) clazz->def->interface)->addObjectsFromArray = addObjectsFromArray;
-	((MutableSetInterface *) clazz->def->interface)->addObjectsFromSet = addObjectsFromSet;
-	((MutableSetInterface *) clazz->def->interface)->filter = filter;
-	((MutableSetInterface *) clazz->def->interface)->init = init;
-	((MutableSetInterface *) clazz->def->interface)->initWithCapacity = initWithCapacity;
-	((MutableSetInterface *) clazz->def->interface)->removeAllObjects = removeAllObjects;
-	((MutableSetInterface *) clazz->def->interface)->removeObject = removeObject;
-	((MutableSetInterface *) clazz->def->interface)->set = set;
-	((MutableSetInterface *) clazz->def->interface)->setWithCapacity = setWithCapacity;
+	((MutableSetInterface *) clazz->interface)->addObject = addObject;
+	((MutableSetInterface *) clazz->interface)->addObjectsFromArray = addObjectsFromArray;
+	((MutableSetInterface *) clazz->interface)->addObjectsFromSet = addObjectsFromSet;
+	((MutableSetInterface *) clazz->interface)->filter = filter;
+	((MutableSetInterface *) clazz->interface)->init = init;
+	((MutableSetInterface *) clazz->interface)->initWithCapacity = initWithCapacity;
+	((MutableSetInterface *) clazz->interface)->removeAllObjects = removeAllObjects;
+	((MutableSetInterface *) clazz->interface)->removeObject = removeObject;
+	((MutableSetInterface *) clazz->interface)->set = set;
+	((MutableSetInterface *) clazz->interface)->setWithCapacity = setWithCapacity;
 }
 
 /**
@@ -292,19 +292,21 @@ static void initialize(Class *clazz) {
  * @memberof MutableSet
  */
 Class *_MutableSet(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "MutableSet";
-		clazz.superclass = _Set();
-		clazz.instanceSize = sizeof(MutableSet);
-		clazz.interfaceOffset = offsetof(MutableSet, interface);
-		clazz.interfaceSize = sizeof(MutableSetInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "MutableSet",
+			.superclass = _Set(),
+			.instanceSize = sizeof(MutableSet),
+			.interfaceOffset = offsetof(MutableSet, interface),
+			.interfaceSize = sizeof(MutableSetInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/MutableString.c
+++ b/Sources/Objectively/MutableString.c
@@ -326,27 +326,27 @@ static void trim(MutableString *self) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->copy = copy;
 
-	((MutableStringInterface *) clazz->def->interface)->appendCharacters = appendCharacters;
-	((MutableStringInterface *) clazz->def->interface)->appendFormat = appendFormat;
-	((MutableStringInterface *) clazz->def->interface)->appendString = appendString;
-	((MutableStringInterface *) clazz->def->interface)->appendVaList = appendVaList;
-	((MutableStringInterface *) clazz->def->interface)->deleteCharactersInRange = deleteCharactersInRange;
-	((MutableStringInterface *) clazz->def->interface)->init = init;
-	((MutableStringInterface *) clazz->def->interface)->initWithCapacity = initWithCapacity;
-	((MutableStringInterface *) clazz->def->interface)->initWithString = initWithString;
-	((MutableStringInterface *) clazz->def->interface)->insertCharactersAtIndex = insertCharactersAtIndex;
-	((MutableStringInterface *) clazz->def->interface)->insertStringAtIndex = insertStringAtIndex;
-	((MutableStringInterface *) clazz->def->interface)->replaceCharactersInRange = replaceCharactersInRange;
-	((MutableStringInterface *) clazz->def->interface)->replaceOccurrencesOfCharacters = replaceOccurrencesOfCharacters;
-	((MutableStringInterface *) clazz->def->interface)->replaceOccurrencesOfCharactersInRange = replaceOccurrencesOfCharactersInRange;
-	((MutableStringInterface *) clazz->def->interface)->replaceOccurrencesOfString = replaceOccurrencesOfString;
-	((MutableStringInterface *) clazz->def->interface)->replaceOccurrencesOfStringInRange = replaceOccurrencesOfStringInRange;
-	((MutableStringInterface *) clazz->def->interface)->replaceStringInRange = replaceStringInRange;
-	((MutableStringInterface *) clazz->def->interface)->string = string;
-	((MutableStringInterface *) clazz->def->interface)->stringWithCapacity = stringWithCapacity;
-	((MutableStringInterface *) clazz->def->interface)->trim = trim;
+	((MutableStringInterface *) clazz->interface)->appendCharacters = appendCharacters;
+	((MutableStringInterface *) clazz->interface)->appendFormat = appendFormat;
+	((MutableStringInterface *) clazz->interface)->appendString = appendString;
+	((MutableStringInterface *) clazz->interface)->appendVaList = appendVaList;
+	((MutableStringInterface *) clazz->interface)->deleteCharactersInRange = deleteCharactersInRange;
+	((MutableStringInterface *) clazz->interface)->init = init;
+	((MutableStringInterface *) clazz->interface)->initWithCapacity = initWithCapacity;
+	((MutableStringInterface *) clazz->interface)->initWithString = initWithString;
+	((MutableStringInterface *) clazz->interface)->insertCharactersAtIndex = insertCharactersAtIndex;
+	((MutableStringInterface *) clazz->interface)->insertStringAtIndex = insertStringAtIndex;
+	((MutableStringInterface *) clazz->interface)->replaceCharactersInRange = replaceCharactersInRange;
+	((MutableStringInterface *) clazz->interface)->replaceOccurrencesOfCharacters = replaceOccurrencesOfCharacters;
+	((MutableStringInterface *) clazz->interface)->replaceOccurrencesOfCharactersInRange = replaceOccurrencesOfCharactersInRange;
+	((MutableStringInterface *) clazz->interface)->replaceOccurrencesOfString = replaceOccurrencesOfString;
+	((MutableStringInterface *) clazz->interface)->replaceOccurrencesOfStringInRange = replaceOccurrencesOfStringInRange;
+	((MutableStringInterface *) clazz->interface)->replaceStringInRange = replaceStringInRange;
+	((MutableStringInterface *) clazz->interface)->string = string;
+	((MutableStringInterface *) clazz->interface)->stringWithCapacity = stringWithCapacity;
+	((MutableStringInterface *) clazz->interface)->trim = trim;
 }
 
 /**
@@ -354,19 +354,21 @@ static void initialize(Class *clazz) {
  * @memberof MutableString
  */
 Class *_MutableString(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "MutableString";
-		clazz.superclass = _String();
-		clazz.instanceSize = sizeof(MutableString);
-		clazz.interfaceOffset = offsetof(MutableString, interface);
-		clazz.interfaceSize = sizeof(MutableStringInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "MutableString",
+			.superclass = _String(),
+			.instanceSize = sizeof(MutableString),
+			.interfaceOffset = offsetof(MutableString, interface),
+			.interfaceSize = sizeof(MutableStringInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Null.c
+++ b/Sources/Objectively/Null.c
@@ -63,9 +63,9 @@ static Null *null(void) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->copy = copy;
 
-	((NullInterface *) clazz->def->interface)->null = null;
+	((NullInterface *) clazz->interface)->null = null;
 }
 
 /**
@@ -81,20 +81,22 @@ static void destroy(Class *clazz) {
  * @memberof Null
  */
 Class *_Null(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Null";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Null);
-		clazz.interfaceOffset = offsetof(Null, interface);
-		clazz.interfaceSize = sizeof(NullInterface);
-		clazz.initialize = initialize;
-		clazz.destroy = destroy;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Null",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Null),
+			.interfaceOffset = offsetof(Null, interface),
+			.interfaceSize = sizeof(NullInterface),
+			.initialize = initialize,
+			.destroy = destroy,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Number.c
+++ b/Sources/Objectively/Number.c
@@ -175,20 +175,20 @@ static short shortValue(const Number *self) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->description = description;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->description = description;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((NumberInterface *) clazz->def->interface)->boolValue = boolValue;
-	((NumberInterface *) clazz->def->interface)->charValue = charValue;
-	((NumberInterface *) clazz->def->interface)->compareTo = compareTo;
-	((NumberInterface *) clazz->def->interface)->doubleValue = doubleValue;
-	((NumberInterface *) clazz->def->interface)->floatValue = floatValue;
-	((NumberInterface *) clazz->def->interface)->longValue = longValue;
-	((NumberInterface *) clazz->def->interface)->initWithValue = initWithValue;
-	((NumberInterface *) clazz->def->interface)->intValue = intValue;
-	((NumberInterface *) clazz->def->interface)->numberWithValue = numberWithValue;
-	((NumberInterface *) clazz->def->interface)->shortValue = shortValue;
+	((NumberInterface *) clazz->interface)->boolValue = boolValue;
+	((NumberInterface *) clazz->interface)->charValue = charValue;
+	((NumberInterface *) clazz->interface)->compareTo = compareTo;
+	((NumberInterface *) clazz->interface)->doubleValue = doubleValue;
+	((NumberInterface *) clazz->interface)->floatValue = floatValue;
+	((NumberInterface *) clazz->interface)->longValue = longValue;
+	((NumberInterface *) clazz->interface)->initWithValue = initWithValue;
+	((NumberInterface *) clazz->interface)->intValue = intValue;
+	((NumberInterface *) clazz->interface)->numberWithValue = numberWithValue;
+	((NumberInterface *) clazz->interface)->shortValue = shortValue;
 }
 
 /**
@@ -196,19 +196,21 @@ static void initialize(Class *clazz) {
  * @memberof Number
  */
 Class *_Number(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Number";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Number);
-		clazz.interfaceOffset = offsetof(Number, interface);
-		clazz.interfaceSize = sizeof(NumberInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Number",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Number),
+			.interfaceOffset = offsetof(Number, interface),
+			.interfaceSize = sizeof(NumberInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/NumberFormatter.c
+++ b/Sources/Objectively/NumberFormatter.c
@@ -79,9 +79,9 @@ static String *stringFromNumber(const NumberFormatter *self, const Number *numbe
  */
 static void initialize(Class *clazz) {
 
-	((NumberFormatterInterface *) clazz->def->interface)->numberFromString = numberFromString;
-	((NumberFormatterInterface *) clazz->def->interface)->initWithFormat = initWithFormat;
-	((NumberFormatterInterface *) clazz->def->interface)->stringFromNumber = stringFromNumber;
+	((NumberFormatterInterface *) clazz->interface)->numberFromString = numberFromString;
+	((NumberFormatterInterface *) clazz->interface)->initWithFormat = initWithFormat;
+	((NumberFormatterInterface *) clazz->interface)->stringFromNumber = stringFromNumber;
 }
 
 /**
@@ -89,19 +89,21 @@ static void initialize(Class *clazz) {
  * @memberof NumberFormatter
  */
 Class *_NumberFormatter(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "NumberFormatter";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(NumberFormatter);
-		clazz.interfaceOffset = offsetof(NumberFormatter, interface);
-		clazz.interfaceSize = sizeof(NumberFormatterInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "NumberFormatter",
+			.superclass = _Object(),
+			.instanceSize = sizeof(NumberFormatter),
+			.interfaceOffset = offsetof(NumberFormatter, interface),
+			.interfaceSize = sizeof(NumberFormatterInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Operation.c
+++ b/Sources/Objectively/Operation.c
@@ -212,18 +212,18 @@ static void waitUntilFinished(const Operation *self) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((OperationInterface *) clazz->def->interface)->addDependency = addDependency;
-	((OperationInterface *) clazz->def->interface)->cancel = cancel;
-	((OperationInterface *) clazz->def->interface)->dependencies = dependencies;
-	((OperationInterface *) clazz->def->interface)->init = init;
-	((OperationInterface *) clazz->def->interface)->initWithFunction = initWithFunction;
-	((OperationInterface *) clazz->def->interface)->isReady = isReady;
-	((OperationInterface *) clazz->def->interface)->removeDependency = removeDepdenency;
-	((OperationInterface *) clazz->def->interface)->start = start;
-	((OperationInterface *) clazz->def->interface)->waitUntilFinished = waitUntilFinished;
+	((OperationInterface *) clazz->interface)->addDependency = addDependency;
+	((OperationInterface *) clazz->interface)->cancel = cancel;
+	((OperationInterface *) clazz->interface)->dependencies = dependencies;
+	((OperationInterface *) clazz->interface)->init = init;
+	((OperationInterface *) clazz->interface)->initWithFunction = initWithFunction;
+	((OperationInterface *) clazz->interface)->isReady = isReady;
+	((OperationInterface *) clazz->interface)->removeDependency = removeDepdenency;
+	((OperationInterface *) clazz->interface)->start = start;
+	((OperationInterface *) clazz->interface)->waitUntilFinished = waitUntilFinished;
 }
 
 /**
@@ -231,19 +231,21 @@ static void initialize(Class *clazz) {
  * @memberof Operation
  */
 Class *_Operation(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Operation";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Operation);
-		clazz.interfaceOffset = offsetof(Operation, interface);
-		clazz.interfaceSize = sizeof(OperationInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Operation",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Operation),
+			.interfaceOffset = offsetof(Operation, interface),
+			.interfaceSize = sizeof(OperationInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/OperationQueue.c
+++ b/Sources/Objectively/OperationQueue.c
@@ -232,17 +232,17 @@ static void waitUntilAllOperationsAreFinished(OperationQueue *self) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((OperationQueueInterface *) clazz->def->interface)->addOperation = addOperation;
-	((OperationQueueInterface *) clazz->def->interface)->cancelAllOperations = cancelAllOperations;
-	((OperationQueueInterface *) clazz->def->interface)->currentQueue = currentQueue;
-	((OperationQueueInterface *) clazz->def->interface)->init = init;
-	((OperationQueueInterface *) clazz->def->interface)->operationCount = operationCount;
-	((OperationQueueInterface *) clazz->def->interface)->operations = operations;
-	((OperationQueueInterface *) clazz->def->interface)->removeOperation = removeOperation;
-	((OperationQueueInterface *) clazz->def->interface)->waitUntilAllOperationsAreFinished = waitUntilAllOperationsAreFinished;
+	((OperationQueueInterface *) clazz->interface)->addOperation = addOperation;
+	((OperationQueueInterface *) clazz->interface)->cancelAllOperations = cancelAllOperations;
+	((OperationQueueInterface *) clazz->interface)->currentQueue = currentQueue;
+	((OperationQueueInterface *) clazz->interface)->init = init;
+	((OperationQueueInterface *) clazz->interface)->operationCount = operationCount;
+	((OperationQueueInterface *) clazz->interface)->operations = operations;
+	((OperationQueueInterface *) clazz->interface)->removeOperation = removeOperation;
+	((OperationQueueInterface *) clazz->interface)->waitUntilAllOperationsAreFinished = waitUntilAllOperationsAreFinished;
 }
 
 /**
@@ -250,18 +250,21 @@ static void initialize(Class *clazz) {
  * @memberof OperationQueue
  */
 Class *_OperationQueue(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "OperationQueue";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(OperationQueue);
-		clazz.interfaceOffset = offsetof(OperationQueue, interface);
-		clazz.interfaceSize = sizeof(OperationQueueInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "OperationQueue",
+			.superclass = _Object(),
+			.instanceSize = sizeof(OperationQueue),
+			.interfaceOffset = offsetof(OperationQueue, interface),
+			.interfaceSize = sizeof(OperationQueueInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
+
 #undef _Class

--- a/Sources/Objectively/Regexp.c
+++ b/Sources/Objectively/Regexp.c
@@ -181,15 +181,15 @@ static _Bool matchesString(const Regexp *self, const String *string, int options
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	((ObjectInterface *) clazz->def->interface)->description = description;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->description = description;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((RegexpInterface *) clazz->def->interface)->initWithPattern = initWithPattern;
-	((RegexpInterface *) clazz->def->interface)->matchesCharacters = matchesCharacters;
-	((RegexpInterface *) clazz->def->interface)->matchesString = matchesString;
+	((RegexpInterface *) clazz->interface)->initWithPattern = initWithPattern;
+	((RegexpInterface *) clazz->interface)->matchesCharacters = matchesCharacters;
+	((RegexpInterface *) clazz->interface)->matchesString = matchesString;
 }
 
 /**
@@ -197,19 +197,21 @@ static void initialize(Class *clazz) {
  * @memberof Regexp
  */
 Class *_Regexp(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Regexp";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Regexp);
-		clazz.interfaceOffset = offsetof(Regexp, interface);
-		clazz.interfaceSize = sizeof(RegexpInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Regexp",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Regexp),
+			.interfaceOffset = offsetof(Regexp, interface),
+			.interfaceSize = sizeof(RegexpInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Resource.c
+++ b/Sources/Objectively/Resource.c
@@ -157,14 +157,14 @@ static void setProvider(ResourceProvider resourceProvider) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((ResourceInterface *) clazz->def->interface)->addResourcePath = addResourcePath;
-	((ResourceInterface *) clazz->def->interface)->initWithData = initWithData;
-	((ResourceInterface *) clazz->def->interface)->initWithName = initWithName;
-	((ResourceInterface *) clazz->def->interface)->removeResourcePath = removeResourcePath;
-	((ResourceInterface *) clazz->def->interface)->resourceWithName = resourceWithName;
-	((ResourceInterface *) clazz->def->interface)->setProvider = setProvider;
+	((ResourceInterface *) clazz->interface)->addResourcePath = addResourcePath;
+	((ResourceInterface *) clazz->interface)->initWithData = initWithData;
+	((ResourceInterface *) clazz->interface)->initWithName = initWithName;
+	((ResourceInterface *) clazz->interface)->removeResourcePath = removeResourcePath;
+	((ResourceInterface *) clazz->interface)->resourceWithName = resourceWithName;
+	((ResourceInterface *) clazz->interface)->setProvider = setProvider;
 
 	_resourcePaths = $(alloc(MutableArray), init);
 	assert(_resourcePaths);
@@ -198,20 +198,22 @@ static void destroy(Class *clazz) {
  * @memberof Resource
  */
 Class *_Resource(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Resource";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Resource);
-		clazz.interfaceOffset = offsetof(Resource, interface);
-		clazz.interfaceSize = sizeof(ResourceInterface);
-		clazz.initialize = initialize;
-		clazz.destroy = destroy;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Resource",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Resource),
+			.interfaceOffset = offsetof(Resource, interface),
+			.interfaceSize = sizeof(ResourceInterface),
+			.initialize = initialize,
+			.destroy = destroy,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Set.c
+++ b/Sources/Objectively/Set.c
@@ -399,25 +399,25 @@ static Set *setWithSet(const Set *set) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	((ObjectInterface *) clazz->def->interface)->description = description;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->description = description;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((SetInterface *) clazz->def->interface)->allObjects = allObjects;
-	((SetInterface *) clazz->def->interface)->containsObject = containsObject;
-	((SetInterface *) clazz->def->interface)->enumerateObjects = enumerateObjects;
-	((SetInterface *) clazz->def->interface)->filteredSet = filteredSet;
-	((SetInterface *) clazz->def->interface)->initWithArray = initWithArray;
-	((SetInterface *) clazz->def->interface)->initWithSet = initWithSet;
-	((SetInterface *) clazz->def->interface)->initWithObjects = initWithObjects;
-	((SetInterface *) clazz->def->interface)->mappedSet = mappedSet;
-	((SetInterface *) clazz->def->interface)->mutableCopy = mutableCopy;
-	((SetInterface *) clazz->def->interface)->reduce = reduce;
-	((SetInterface *) clazz->def->interface)->setWithArray = setWithArray;
-	((SetInterface *) clazz->def->interface)->setWithObjects = setWithObjects;
-	((SetInterface *) clazz->def->interface)->setWithSet = setWithSet;
+	((SetInterface *) clazz->interface)->allObjects = allObjects;
+	((SetInterface *) clazz->interface)->containsObject = containsObject;
+	((SetInterface *) clazz->interface)->enumerateObjects = enumerateObjects;
+	((SetInterface *) clazz->interface)->filteredSet = filteredSet;
+	((SetInterface *) clazz->interface)->initWithArray = initWithArray;
+	((SetInterface *) clazz->interface)->initWithSet = initWithSet;
+	((SetInterface *) clazz->interface)->initWithObjects = initWithObjects;
+	((SetInterface *) clazz->interface)->mappedSet = mappedSet;
+	((SetInterface *) clazz->interface)->mutableCopy = mutableCopy;
+	((SetInterface *) clazz->interface)->reduce = reduce;
+	((SetInterface *) clazz->interface)->setWithArray = setWithArray;
+	((SetInterface *) clazz->interface)->setWithObjects = setWithObjects;
+	((SetInterface *) clazz->interface)->setWithSet = setWithSet;
 }
 
 /**
@@ -425,19 +425,21 @@ static void initialize(Class *clazz) {
  * @memberof Set
  */
 Class *_Set(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Set";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Set);
-		clazz.interfaceOffset = offsetof(Set, interface);
-		clazz.interfaceSize = sizeof(SetInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Set",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Set),
+			.interfaceOffset = offsetof(Set, interface),
+			.interfaceSize = sizeof(SetInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/String.c
+++ b/Sources/Objectively/String.c
@@ -614,39 +614,39 @@ static _Bool writeToFile(const String *self, const char *path, StringEncoding en
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	((ObjectInterface *) clazz->def->interface)->description = description;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->description = description;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((StringInterface *) clazz->def->interface)->compareTo = compareTo;
-	((StringInterface *) clazz->def->interface)->componentsSeparatedByCharacters = componentsSeparatedByCharacters;
-	((StringInterface *) clazz->def->interface)->componentsSeparatedByString = componentsSeparatedByString;
-	((StringInterface *) clazz->def->interface)->getData = getData;
-	((StringInterface *) clazz->def->interface)->hasPrefix = hasPrefix;
-	((StringInterface *) clazz->def->interface)->hasSuffix = hasSuffix;
-	((StringInterface *) clazz->def->interface)->initWithBytes = initWithBytes;
-	((StringInterface *) clazz->def->interface)->initWithCharacters = initWithCharacters;
-	((StringInterface *) clazz->def->interface)->initWithContentsOfFile = initWithContentsOfFile;
-	((StringInterface *) clazz->def->interface)->initWithData = initWithData;
-	((StringInterface *) clazz->def->interface)->initWithFormat = initWithFormat;
-	((StringInterface *) clazz->def->interface)->initWithMemory = initWithMemory;
-	((StringInterface *) clazz->def->interface)->initWithVaList = initWithVaList;
-	((StringInterface *) clazz->def->interface)->lowercaseString = lowercaseString;
-	((StringInterface *) clazz->def->interface)->mutableCopy = mutableCopy;
-	((StringInterface *) clazz->def->interface)->rangeOfCharacters = rangeOfCharacters;
-	((StringInterface *) clazz->def->interface)->rangeOfString = rangeOfString;
-	((StringInterface *) clazz->def->interface)->stringWithBytes = stringWithBytes;
-	((StringInterface *) clazz->def->interface)->stringWithCharacters = stringWithCharacters;
-	((StringInterface *) clazz->def->interface)->stringWithContentsOfFile = stringWithContentsOfFile;
-	((StringInterface *) clazz->def->interface)->stringWithData = stringWithData;
-	((StringInterface *) clazz->def->interface)->stringWithFormat = stringWithFormat;
-	((StringInterface *) clazz->def->interface)->stringWithMemory = stringWithMemory;
-	((StringInterface *) clazz->def->interface)->substring = substring;
-	((StringInterface *) clazz->def->interface)->trimmedString = trimmedString;
-	((StringInterface *) clazz->def->interface)->uppercaseString = uppercaseString;
-	((StringInterface *) clazz->def->interface)->writeToFile = writeToFile;
+	((StringInterface *) clazz->interface)->compareTo = compareTo;
+	((StringInterface *) clazz->interface)->componentsSeparatedByCharacters = componentsSeparatedByCharacters;
+	((StringInterface *) clazz->interface)->componentsSeparatedByString = componentsSeparatedByString;
+	((StringInterface *) clazz->interface)->getData = getData;
+	((StringInterface *) clazz->interface)->hasPrefix = hasPrefix;
+	((StringInterface *) clazz->interface)->hasSuffix = hasSuffix;
+	((StringInterface *) clazz->interface)->initWithBytes = initWithBytes;
+	((StringInterface *) clazz->interface)->initWithCharacters = initWithCharacters;
+	((StringInterface *) clazz->interface)->initWithContentsOfFile = initWithContentsOfFile;
+	((StringInterface *) clazz->interface)->initWithData = initWithData;
+	((StringInterface *) clazz->interface)->initWithFormat = initWithFormat;
+	((StringInterface *) clazz->interface)->initWithMemory = initWithMemory;
+	((StringInterface *) clazz->interface)->initWithVaList = initWithVaList;
+	((StringInterface *) clazz->interface)->lowercaseString = lowercaseString;
+	((StringInterface *) clazz->interface)->mutableCopy = mutableCopy;
+	((StringInterface *) clazz->interface)->rangeOfCharacters = rangeOfCharacters;
+	((StringInterface *) clazz->interface)->rangeOfString = rangeOfString;
+	((StringInterface *) clazz->interface)->stringWithBytes = stringWithBytes;
+	((StringInterface *) clazz->interface)->stringWithCharacters = stringWithCharacters;
+	((StringInterface *) clazz->interface)->stringWithContentsOfFile = stringWithContentsOfFile;
+	((StringInterface *) clazz->interface)->stringWithData = stringWithData;
+	((StringInterface *) clazz->interface)->stringWithFormat = stringWithFormat;
+	((StringInterface *) clazz->interface)->stringWithMemory = stringWithMemory;
+	((StringInterface *) clazz->interface)->substring = substring;
+	((StringInterface *) clazz->interface)->trimmedString = trimmedString;
+	((StringInterface *) clazz->interface)->uppercaseString = uppercaseString;
+	((StringInterface *) clazz->interface)->writeToFile = writeToFile;
 
 	setlocale(LC_CTYPE, "");
 }
@@ -656,19 +656,21 @@ static void initialize(Class *clazz) {
  * @memberof String
  */
 Class *_String(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "String";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(String);
-		clazz.interfaceOffset = offsetof(String, interface);
-		clazz.interfaceSize = sizeof(StringInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "String",
+			.superclass = _Object(),
+			.instanceSize = sizeof(String),
+			.interfaceOffset = offsetof(String, interface),
+			.interfaceSize = sizeof(StringInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/StringReader.c
+++ b/Sources/Objectively/StringReader.c
@@ -173,16 +173,16 @@ static void reset(StringReader *self) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((StringReaderInterface *) clazz->def->interface)->initWithCharacters = initWithCharacters;
-	((StringReaderInterface *) clazz->def->interface)->initWithString = initWithString;
-	((StringReaderInterface *) clazz->def->interface)->next = next;
-	((StringReaderInterface *) clazz->def->interface)->peek = peek;
-	((StringReaderInterface *) clazz->def->interface)->read = read;
-	((StringReaderInterface *) clazz->def->interface)->readToken = readToken;
-	((StringReaderInterface *) clazz->def->interface)->reset = reset;
+	((StringReaderInterface *) clazz->interface)->initWithCharacters = initWithCharacters;
+	((StringReaderInterface *) clazz->interface)->initWithString = initWithString;
+	((StringReaderInterface *) clazz->interface)->next = next;
+	((StringReaderInterface *) clazz->interface)->peek = peek;
+	((StringReaderInterface *) clazz->interface)->read = read;
+	((StringReaderInterface *) clazz->interface)->readToken = readToken;
+	((StringReaderInterface *) clazz->interface)->reset = reset;
 }
 
 /**
@@ -190,19 +190,21 @@ static void initialize(Class *clazz) {
  * @memberof StringReader
  */
 Class *_StringReader(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "StringReader";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(StringReader);
-		clazz.interfaceOffset = offsetof(StringReader, interface);
-		clazz.interfaceSize = sizeof(StringReaderInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "StringReader",
+			.superclass = _Object(),
+			.instanceSize = sizeof(StringReader),
+			.interfaceOffset = offsetof(StringReader, interface),
+			.interfaceSize = sizeof(StringReaderInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Thread.c
+++ b/Sources/Objectively/Thread.c
@@ -185,17 +185,17 @@ static void start(Thread *self) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((ThreadInterface *) clazz->def->interface)->cancel = cancel;
-	((ThreadInterface *) clazz->def->interface)->currentThread = currentThread;
-	((ThreadInterface *) clazz->def->interface)->detach = detach;
-	((ThreadInterface *) clazz->def->interface)->init = init;
-	((ThreadInterface *) clazz->def->interface)->initWithFunction = initWithFunction;
-	((ThreadInterface *) clazz->def->interface)->join = join;
-	((ThreadInterface *) clazz->def->interface)->kill = _kill;
-	((ThreadInterface *) clazz->def->interface)->start = start;
+	((ThreadInterface *) clazz->interface)->cancel = cancel;
+	((ThreadInterface *) clazz->interface)->currentThread = currentThread;
+	((ThreadInterface *) clazz->interface)->detach = detach;
+	((ThreadInterface *) clazz->interface)->init = init;
+	((ThreadInterface *) clazz->interface)->initWithFunction = initWithFunction;
+	((ThreadInterface *) clazz->interface)->join = join;
+	((ThreadInterface *) clazz->interface)->kill = _kill;
+	((ThreadInterface *) clazz->interface)->start = start;
 }
 
 /**
@@ -203,19 +203,21 @@ static void initialize(Class *clazz) {
  * @memberof Thread
  */
 Class *_Thread(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Thread";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Thread);
-		clazz.interfaceOffset = offsetof(Thread, interface);
-		clazz.interfaceSize = sizeof(ThreadInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Thread",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Thread),
+			.interfaceOffset = offsetof(Thread, interface),
+			.interfaceSize = sizeof(ThreadInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/URL.c
+++ b/Sources/Objectively/URL.c
@@ -219,16 +219,16 @@ static Array *pathComponents(const URL *self) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	((ObjectInterface *) clazz->def->interface)->description = description;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->description = description;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((URLInterface *) clazz->def->interface)->baseURL = baseURL;
-	((URLInterface *) clazz->def->interface)->initWithCharacters = initWithCharacters;
-	((URLInterface *) clazz->def->interface)->initWithString = initWithString;
-	((URLInterface *) clazz->def->interface)->pathComponents = pathComponents;
+	((URLInterface *) clazz->interface)->baseURL = baseURL;
+	((URLInterface *) clazz->interface)->initWithCharacters = initWithCharacters;
+	((URLInterface *) clazz->interface)->initWithString = initWithString;
+	((URLInterface *) clazz->interface)->pathComponents = pathComponents;
 
 	_re = re("([a-z]+)://([^:/\?]+)?(:[0-9]+)?(/[^\?#]+)?([^#]+)?(#.*)?", 0);
 }
@@ -246,20 +246,22 @@ static void destroy(Class *clazz) {
  * @memberof URL
  */
 Class *_URL(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "URL";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(URL);
-		clazz.interfaceOffset = offsetof(URL, interface);
-		clazz.interfaceSize = sizeof(URLInterface);
-		clazz.initialize = initialize;
-		clazz.destroy = destroy;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "URL",
+			.superclass = _Object(),
+			.instanceSize = sizeof(URL),
+			.interfaceOffset = offsetof(URL, interface),
+			.interfaceSize = sizeof(URLInterface),
+			.initialize = initialize,
+			.destroy = destroy,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/URLRequest.c
+++ b/Sources/Objectively/URLRequest.c
@@ -107,11 +107,11 @@ void setValueForHTTPHeaderField(URLRequest *self, const char *value, const char 
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((URLRequestInterface *) clazz->def->interface)->initWithURL = initWithURL;
-	((URLRequestInterface *) clazz->def->interface)->setValueForHTTPHeaderField = setValueForHTTPHeaderField;
+	((URLRequestInterface *) clazz->interface)->initWithURL = initWithURL;
+	((URLRequestInterface *) clazz->interface)->setValueForHTTPHeaderField = setValueForHTTPHeaderField;
 }
 
 /**
@@ -119,19 +119,21 @@ static void initialize(Class *clazz) {
  * @memberof URLRequest
  */
 Class *_URLRequest(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "URLRequest";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(URLRequest);
-		clazz.interfaceOffset = offsetof(URLRequest, interface);
-		clazz.interfaceSize = sizeof(URLRequestInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "URLRequest",
+			.superclass = _Object(),
+			.instanceSize = sizeof(URLRequest),
+			.interfaceOffset = offsetof(URLRequest, interface),
+			.interfaceSize = sizeof(URLRequestInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/URLSession.c
+++ b/Sources/Objectively/URLSession.c
@@ -344,18 +344,18 @@ static URLSessionUploadTask *uploadTaskWithRequest(URLSession *self, URLRequest 
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((URLSessionInterface *) clazz->def->interface)->dataTaskWithRequest = dataTaskWithRequest;
-	((URLSessionInterface *) clazz->def->interface)->dataTaskWithURL = dataTaskWithURL;
-	((URLSessionInterface *) clazz->def->interface)->downloadTaskWithRequest = downloadTaskWithRequest;
-	((URLSessionInterface *) clazz->def->interface)->downloadTaskWithURL = downloadTaskWithURL;
-	((URLSessionInterface *) clazz->def->interface)->init = init;
-	((URLSessionInterface *) clazz->def->interface)->initWithConfiguration = initWithConfiguration;
-	((URLSessionInterface *) clazz->def->interface)->invalidateAndCancel = invalidateAndCancel;
-	((URLSessionInterface *) clazz->def->interface)->sharedInstance = sharedInstance;
-	((URLSessionInterface *) clazz->def->interface)->tasks = tasks;
-	((URLSessionInterface *) clazz->def->interface)->uploadTaskWithRequest = uploadTaskWithRequest;
+	((URLSessionInterface *) clazz->interface)->dataTaskWithRequest = dataTaskWithRequest;
+	((URLSessionInterface *) clazz->interface)->dataTaskWithURL = dataTaskWithURL;
+	((URLSessionInterface *) clazz->interface)->downloadTaskWithRequest = downloadTaskWithRequest;
+	((URLSessionInterface *) clazz->interface)->downloadTaskWithURL = downloadTaskWithURL;
+	((URLSessionInterface *) clazz->interface)->init = init;
+	((URLSessionInterface *) clazz->interface)->initWithConfiguration = initWithConfiguration;
+	((URLSessionInterface *) clazz->interface)->invalidateAndCancel = invalidateAndCancel;
+	((URLSessionInterface *) clazz->interface)->sharedInstance = sharedInstance;
+	((URLSessionInterface *) clazz->interface)->tasks = tasks;
+	((URLSessionInterface *) clazz->interface)->uploadTaskWithRequest = uploadTaskWithRequest;
 
 	const CURLcode code = curl_global_init(CURL_GLOBAL_ALL);
 	assert(code == CURLE_OK);
@@ -376,20 +376,22 @@ static void destroy(Class *clazz) {
  * @memberof URLSession
  */
 Class *_URLSession(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "URLSession";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(URLSession);
-		clazz.interfaceOffset = offsetof(URLSession, interface);
-		clazz.interfaceSize = sizeof(URLSessionInterface);
-		clazz.initialize = initialize;
-		clazz.destroy = destroy;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "URLSession",
+			.superclass = _Object(),
+			.instanceSize = sizeof(URLSession),
+			.interfaceOffset = offsetof(URLSession, interface),
+			.interfaceSize = sizeof(URLSessionInterface),
+			.initialize = initialize,
+			.destroy = destroy,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/URLSessionConfiguration.c
+++ b/Sources/Objectively/URLSessionConfiguration.c
@@ -50,9 +50,9 @@ static URLSessionConfiguration *init(URLSessionConfiguration *self) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((URLSessionConfigurationInterface *) clazz->def->interface)->init = init;
+	((URLSessionConfigurationInterface *) clazz->interface)->init = init;
 }
 
 /**
@@ -60,19 +60,21 @@ static void initialize(Class *clazz) {
  * @memberof URLSessionConfiguration
  */
 Class *_URLSessionConfiguration(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "URLSessionConfiguration";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(URLSessionConfiguration);
-		clazz.interfaceOffset = offsetof(URLSessionConfiguration, interface);
-		clazz.interfaceSize = sizeof(URLSessionConfigurationInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "URLSessionConfiguration",
+			.superclass = _Object(),
+			.instanceSize = sizeof(URLSessionConfiguration),
+			.interfaceOffset = offsetof(URLSessionConfiguration, interface),
+			.interfaceSize = sizeof(URLSessionConfigurationInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/URLSessionDataTask.c
+++ b/Sources/Objectively/URLSessionDataTask.c
@@ -87,9 +87,9 @@ static void setup(URLSessionTask *self) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((URLSessionTaskInterface *) clazz->def->interface)->setup = setup;
+	((URLSessionTaskInterface *) clazz->interface)->setup = setup;
 }
 
 /**
@@ -97,19 +97,21 @@ static void initialize(Class *clazz) {
  * @memberof URLSessionDataTask
  */
 Class *_URLSessionDataTask(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "URLSessionDataTask";
-		clazz.superclass = _URLSessionTask();
-		clazz.instanceSize = sizeof(URLSessionDataTask);
-		clazz.interfaceOffset = offsetof(URLSessionDataTask, interface);
-		clazz.interfaceSize = sizeof(URLSessionDataTaskInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "URLSessionDataTask",
+			.superclass = _URLSessionTask(),
+			.instanceSize = sizeof(URLSessionDataTask),
+			.interfaceOffset = offsetof(URLSessionDataTask, interface),
+			.interfaceSize = sizeof(URLSessionDataTaskInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/URLSessionDownloadTask.c
+++ b/Sources/Objectively/URLSessionDownloadTask.c
@@ -67,7 +67,7 @@ static void setup(URLSessionTask *self) {
  */
 static void initialize(Class *clazz) {
 
-	((URLSessionTaskInterface *) clazz->def->interface)->setup = setup;
+	((URLSessionTaskInterface *) clazz->interface)->setup = setup;
 }
 
 /**
@@ -75,19 +75,21 @@ static void initialize(Class *clazz) {
  * @memberof URLSessionDownloadTask
  */
 Class *_URLSessionDownloadTask(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "URLSessionDownloadTask";
-		clazz.superclass = _URLSessionTask();
-		clazz.instanceSize = sizeof(URLSessionDownloadTask);
-		clazz.interfaceOffset = offsetof(URLSessionDownloadTask, interface);
-		clazz.interfaceSize = sizeof(URLSessionDownloadTaskInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "URLSessionDownloadTask",
+			.superclass = _URLSessionTask(),
+			.instanceSize = sizeof(URLSessionDownloadTask),
+			.interfaceOffset = offsetof(URLSessionDownloadTask, interface),
+			.interfaceSize = sizeof(URLSessionDownloadTaskInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/URLSessionTask.c
+++ b/Sources/Objectively/URLSessionTask.c
@@ -249,15 +249,15 @@ static void teardown(URLSessionTask *self) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->copy = copy;
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->copy = copy;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((URLSessionTaskInterface *) clazz->def->interface)->cancel = cancel;
-	((URLSessionTaskInterface *) clazz->def->interface)->initWithRequestInSession = initWithRequestInSession;
-	((URLSessionTaskInterface *) clazz->def->interface)->resume = resume;
-	((URLSessionTaskInterface *) clazz->def->interface)->setup = setup;
-	((URLSessionTaskInterface *) clazz->def->interface)->suspend = suspend;
-	((URLSessionTaskInterface *) clazz->def->interface)->teardown = teardown;
+	((URLSessionTaskInterface *) clazz->interface)->cancel = cancel;
+	((URLSessionTaskInterface *) clazz->interface)->initWithRequestInSession = initWithRequestInSession;
+	((URLSessionTaskInterface *) clazz->interface)->resume = resume;
+	((URLSessionTaskInterface *) clazz->interface)->setup = setup;
+	((URLSessionTaskInterface *) clazz->interface)->suspend = suspend;
+	((URLSessionTaskInterface *) clazz->interface)->teardown = teardown;
 }
 
 /**
@@ -265,19 +265,21 @@ static void initialize(Class *clazz) {
  * @memberof URLSessionTask
  */
 Class *_URLSessionTask(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "URLSessionTask";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(URLSessionTask);
-		clazz.interfaceOffset = offsetof(URLSessionTask, interface);
-		clazz.interfaceSize = sizeof(URLSessionTaskInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "URLSessionTask",
+			.superclass = _Object(),
+			.instanceSize = sizeof(URLSessionTask),
+			.interfaceOffset = offsetof(URLSessionTask, interface),
+			.interfaceSize = sizeof(URLSessionTaskInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/URLSessionUploadTask.c
+++ b/Sources/Objectively/URLSessionUploadTask.c
@@ -77,7 +77,7 @@ static void setup(URLSessionTask *self) {
  */
 static void initialize(Class *clazz) {
 
-	((URLSessionTaskInterface *) clazz->def->interface)->setup = setup;
+	((URLSessionTaskInterface *) clazz->interface)->setup = setup;
 }
 
 /**
@@ -85,19 +85,21 @@ static void initialize(Class *clazz) {
  * @memberof URLSessionUploadTask
  */
 Class *_URLSessionUploadTask(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "URLSessionUploadTask";
-		clazz.superclass = _URLSessionTask();
-		clazz.instanceSize = sizeof(URLSessionUploadTask);
-		clazz.interfaceOffset = offsetof(URLSessionUploadTask, interface);
-		clazz.interfaceSize = sizeof(URLSessionUploadTaskInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "URLSessionUploadTask",
+			.superclass = _URLSessionTask(),
+			.instanceSize = sizeof(URLSessionUploadTask),
+			.interfaceOffset = offsetof(URLSessionUploadTask, interface),
+			.interfaceSize = sizeof(URLSessionUploadTaskInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Sources/Objectively/Value.c
+++ b/Sources/Objectively/Value.c
@@ -100,11 +100,11 @@ static Value *initWithValue(Value *self, ident value) {
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
-	((ObjectInterface *) clazz->def->interface)->hash = hash;
-	((ObjectInterface *) clazz->def->interface)->isEqual = isEqual;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->hash = hash;
+	((ObjectInterface *) clazz->interface)->isEqual = isEqual;
 
-	((ValueInterface *) clazz->def->interface)->initWithValue = initWithValue;
+	((ValueInterface *) clazz->interface)->initWithValue = initWithValue;
 }
 
 /**
@@ -112,19 +112,21 @@ static void initialize(Class *clazz) {
  * @memberof Value
  */
 Class *_Value(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "Value";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(Value);
-		clazz.interfaceOffset = offsetof(Value, interface);
-		clazz.interfaceSize = sizeof(ValueInterface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "Value",
+			.superclass = _Object(),
+			.instanceSize = sizeof(Value),
+			.interfaceOffset = offsetof(Value, interface),
+			.interfaceSize = sizeof(ValueInterface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Templates/Eclipse/eclipse-code-templates.xml
+++ b/Templates/Eclipse/eclipse-code-templates.xml
@@ -56,19 +56,21 @@ static void initialize(Class *clazz) {
  * @memberof ${file_base}
  */
 Class *_${file_base}(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&amp;once, {
-		clazz.name = "${file_base}";
-		clazz.superclass = _Object();
-		clazz.instanceSize = sizeof(${file_base});
-		clazz.interfaceOffset = offsetof(${file_base}, interface);
-		clazz.interfaceSize = sizeof(${file_base}Interface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&amp;(const ClassDef) {
+			.name = "${file_base}",
+			.superclass = _Object(),
+			.instanceSize = sizeof(${file_base}),
+			.interfaceOffset = offsetof(${file_base}, interface),
+			.interfaceSize = sizeof(${file_base}Interface),
+			.initialize = initialize,
+		});
 	});
 
-	return &amp;clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Templates/Xcode/Objectively C Type.xctemplate/___FILEBASENAME___.c
+++ b/Templates/Xcode/Objectively C Type.xctemplate/___FILEBASENAME___.c
@@ -50,9 +50,9 @@ static ___FILEBASENAMEASIDENTIFIER___ *init(___FILEBASENAMEASIDENTIFIER___ *self
  */
 static void initialize(Class *clazz) {
 
-	((ObjectInterface *) clazz->def->interface)->dealloc = dealloc;
+	((ObjectInterface *) clazz->interface)->dealloc = dealloc;
 
-	((___FILEBASENAMEASIDENTIFIER___Interface *) clazz->def->interface)->init = init;
+	((___FILEBASENAMEASIDENTIFIER___Interface *) clazz->interface)->init = init;
 
 	//..
 }
@@ -62,19 +62,21 @@ static void initialize(Class *clazz) {
  * @memberof ___FILEBASENAMEASIDENTIFIER___
  */
 Class *____FILEBASENAMEASIDENTIFIER___(void) {
-	static Class clazz;
+	static Class *clazz;
 	static Once once;
 
 	do_once(&once, {
-		clazz.name = "___FILEBASENAMEASIDENTIFIER___";
-		clazz.superclass = ____VARIABLE_superclass:identifier___();
-		clazz.instanceSize = sizeof(___FILEBASENAMEASIDENTIFIER___);
-		clazz.interfaceOffset = offsetof(___FILEBASENAMEASIDENTIFIER___, interface);
-		clazz.interfaceSize = sizeof(___FILEBASENAMEASIDENTIFIER___Interface);
-		clazz.initialize = initialize;
+		clazz = _initialize(&(const ClassDef) {
+			.name = "___FILEBASENAMEASIDENTIFIER___",
+			.superclass = ____VARIABLE_superclass:identifier___(),
+			.instanceSize = sizeof(___FILEBASENAMEASIDENTIFIER___),
+			.interfaceOffset = offsetof(___FILEBASENAMEASIDENTIFIER___, interface),
+			.interfaceSize = sizeof(___FILEBASENAMEASIDENTIFIER___Interface),
+			.initialize = initialize,
+		});
 	});
 
-	return &clazz;
+	return clazz;
 }
 
 #undef _Class

--- a/Tests/Objectively/Object.c
+++ b/Tests/Objectively/Object.c
@@ -30,7 +30,7 @@ START_TEST(object)
 		Class *clazz = classForName("Object");
 		ck_assert(clazz);
 
-		ck_assert_ptr_eq(&_Object()->def->descriptor, clazz);
+		ck_assert_ptr_eq(_Object(), clazz);
 
 		Object *object = $(alloc(Object), init);
 

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 AC_PREREQ(2.69)
 
-AC_INIT([Objectively], [0.5.0], [jay@jaydolan.com])
+AC_INIT([Objectively], [1.0.0], [jay@jaydolan.com])
 
 AC_CONFIG_HEADERS([Sources/Objectively/Config.h])
 AC_CONFIG_MACRO_DIR([m4])


### PR DESCRIPTION
Refactor Class and ClassDef to more logically represent the runtime representation of a Class, and a static Class definition or descriptor, respectively. Simplifies Class initialization by tackling it immediately in the archetype function, including superclass chaining.