### PR TITLE
Resolve Class archetypes across loaded modules on Windows

### DIFF
--- a/Sources/Objectively/Class.c
+++ b/Sources/Objectively/Class.c
@@ -33,6 +33,11 @@
 #include <unistd.h>
 #endif
 
+#if defined(_WIN32)
+#include <Windows.h>
+#include <TlHelp32.h>
+#endif
+
 #include "Class.h"
 #include "Object.h"
 
@@ -158,6 +163,49 @@ ident _cast(const Class *clazz, const ident obj) {
   return (ident) obj;
 }
 
+/**
+ * @brief The Class archetype constructor signature, e.g. `_Object`.
+ */
+typedef Class *(*Archetype)(void);
+
+/**
+ * @brief Resolves a Class archetype by its exported symbol name.
+ * @remarks On ELF and Mach-O, `dlsym` against the global handle resolves symbols
+ * in every loaded object. The Windows `dlfcn` shim only searches the executable
+ * and explicitly `dlopen`'d libraries, so archetypes exported by implicitly linked
+ * DLLs (e.g. ObjectivelyMVC) are invisible to it. Enumerate the process' loaded
+ * modules and resolve the symbol directly.
+ */
+static Archetype archetypeForSymbol(const char *symbol) {
+
+#if defined(_WIN32)
+  Archetype archetype = NULL;
+
+  HANDLE snapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE, 0);
+  if (snapshot != INVALID_HANDLE_VALUE) {
+
+    MODULEENTRY32 module;
+    module.dwSize = sizeof(module);
+
+    if (Module32First(snapshot, &module)) {
+      do {
+        FARPROC proc = GetProcAddress(module.hModule, symbol);
+        if (proc) {
+          archetype = (Archetype) (void *) proc;
+          break;
+        }
+      } while (Module32Next(snapshot, &module));
+    }
+
+    CloseHandle(snapshot);
+  }
+
+  return archetype;
+#else
+  return (Archetype) dlsym(RTLD_DEFAULT, symbol);
+#endif
+}
+
 Class *classForName(const char *name) {
 
   if (name) {
@@ -172,7 +220,7 @@ Class *classForName(const char *name) {
     char *s;
     if (asprintf(&s, "_%s", name) > 0) {
       Class *clazz = NULL;
-      Class *(*archetype)(void) = dlsym(RTLD_DEFAULT, s);
+      const Archetype archetype = archetypeForSymbol(s);
       if (archetype) {
         clazz = archetype();
       }


### PR DESCRIPTION
﻿## Summary

`classForName()` returns `NULL` on Windows for any class that has not already been registered, causing the caller to crash in `_alloc()`. This breaks every consumer that resolves classes by name at runtime — most visibly ObjectivelyMVC, which instantiates views named in JSON (e.g. an `ImageView` in a `.json` layout) and faults on the very first one.

## Cause

When a name is not found in the `_classes` registry, `classForName()` falls back to resolving the `_<Name>` archetype via `dlsym(dlopen(NULL, 0), ...)`. On ELF and Mach-O, the global handle resolves symbols in **every** loaded object, so an archetype exported by any linked library is found.

The Windows `dlfcn` shim (dlfcn-win32) does not behave the same way: its default handle only searches the executable and libraries opened explicitly with `dlopen(..., RTLD_GLOBAL)`. Archetypes exported by **implicitly (load-time) linked** DLLs — such as `ObjectivelyMVC.dll` — are therefore invisible to `dlsym`, so the archetype is never found, `classForName()` returns `NULL`, and the caller dereferences it.

## Changes

- Add `archetypeForSymbol()` which, on Windows, enumerates the process' loaded modules via the Toolhelp snapshot API (`CreateToolhelp32Snapshot` / `Module32First` / `Module32Next`) and resolves the symbol with `GetProcAddress`. The `dlsym(dlopen(NULL, 0), ...)` path is unchanged on all other platforms.
- Route `classForName()`'s fallback through the helper.

No public API or ABI changes; struct layouts are untouched.

## Testing

- Built `Objectively` Release x64 (VS2022 / clang-cl); the changed file compiles cleanly with no new warnings.
- Verified against a real downstream crash: Quetoo (Objectively 2.x + ObjectivelyMVC) on Windows previously crashed 100% of the time loading its main menu (`READ` access violation at `View+JSON.c` `bindView`, instantiating the first `ImageView` named in `MainView.json`). With only the rebuilt `Objectively.dll` swapped in, the menu builds and the client runs normally.
- Non-Windows code paths are unaffected by the change.
