### PR TITLE
classForName: resolve classes on Windows via dlopen(NULL)

### DIFF
--- a/Sources/Objectively/Class.c
+++ b/Sources/Objectively/Class.c
@@ -172,7 +172,17 @@ Class *classForName(const char *name) {
     char *s;
     if (asprintf(&s, "_%s", name) > 0) {
       Class *clazz = NULL;
+#if defined(_WIN32)
+      // dlfcn-win32's RTLD_DEFAULT is a null handle; dlopen(NULL) yields a
+      // global handle whose dlsym searches all loaded modules (exe and DLLs).
+      static ident self;
+      if (self == NULL) {
+        self = dlopen(NULL, RTLD_LAZY);
+      }
+      Class *(*archetype)(void) = dlsym(self, s);
+#else
       Class *(*archetype)(void) = dlsym(RTLD_DEFAULT, s);
+#endif
       if (archetype) {
         clazz = archetype();
       }


### PR DESCRIPTION
## Summary

`8ad15b2` ("iOS support (#29)") changed `classForName` from a cached `dlopen(NULL,0)` handle to `dlsym(RTLD_DEFAULT, ...)`. That works on Linux/Apple, where `RTLD_DEFAULT` is a special handle that searches every loaded image — but **dlfcn-win32 defines `RTLD_DEFAULT` as `0`** (a null handle), so `dlsym(RTLD_DEFAULT, ...)` always returns `NULL` on Windows.

As a result, any class resolved only by name (e.g. a `View` subclass instantiated from JSON) fails on Windows: `classForName` returns `NULL`, and callers crash — an `assert` in debug builds, a `NULL` dereference in release.

## Fix

On Windows, use the `dlopen(NULL)` global handle (restoring the pre-#29 behavior), whose `dlsym` enumerates all loaded modules. `RTLD_DEFAULT` is kept on other platforms.

## Testing

Verified against Quetoo on Windows (x64, ClangCL): before this change the client crashes at startup resolving the first JSON-only class (`ImageView`, in the main menu); after, the menu loads and the game runs. Linux/Apple paths are unchanged.

## Note

Full disclosure: I worked this up with Claude Code while getting a Windows build going, so it reflects my read of the #29 regression rather than your intent. If you'd rather handle the platform difference another way — or fix it down in dlfcn-win32's `RTLD_DEFAULT` itself — please don't feel bound by this. Happy to defer or adjust.
