### PR TITLE
Class: use dlopen(NULL) for classForName symbol lookup on Windows

### DIFF
--- a/Sources/Objectively/Class.c
+++ b/Sources/Objectively/Class.c
@@ -172,7 +172,15 @@ Class *classForName(const char *name) {
     char *s;
     if (asprintf(&s, "_%s", name) > 0) {
       Class *clazz = NULL;
+#if defined(_WIN32)
+      static ident handle;
+      if (handle == NULL) {
+        handle = dlopen(NULL, RTLD_LAZY);
+      }
+      Class *(*archetype)(void) = dlsym(handle, s);
+#else
       Class *(*archetype)(void) = dlsym(RTLD_DEFAULT, s);
+#endif
       if (archetype) {
         clazz = archetype();
       }

--- a/Sources/Objectively/Class.c
+++ b/Sources/Objectively/Class.c
@@ -173,11 +173,10 @@ Class *classForName(const char *name) {
     if (asprintf(&s, "_%s", name) > 0) {
       Class *clazz = NULL;
 #if defined(_WIN32)
+      static Once once;
       static ident handle;
-      if (handle == NULL) {
-        handle = dlopen(NULL, RTLD_LAZY);
-      }
-      Class *(*archetype)(void) = dlsym(handle, s);
+      do_once(&once, { handle = dlopen(NULL, RTLD_LAZY); });
+      Class *(*archetype)(void) = handle ? dlsym(handle, s) : NULL;
 #else
       Class *(*archetype)(void) = dlsym(RTLD_DEFAULT, s);
 #endif


### PR DESCRIPTION
dlsym(RTLD_DEFAULT) via the dlfcn-win32 shim does not search all loaded modules. On Windows, open the process handle with dlopen(NULL) and use that for dlsym instead. Non-Windows platforms retain RTLD_DEFAULT, preserving the iOS dynamic-framework resolution from #29.

Closes #33.