### PR TITLE
Use Consumer for destroy funcs; add Vector destroy support

### DIFF
--- a/Sources/Objectively/HashTable.h
+++ b/Sources/Objectively/HashTable.h
@@ -44,11 +44,6 @@ typedef size_t (*HashTableHashFunc)(const ident key);
 typedef bool (*HashTableEqualFunc)(const ident a, const ident b);
 
 /**
- * @brief A function called to destroy a key or value on removal.
- */
-typedef void (*HashTableDestroyFunc)(ident obj);
-
-/**
  * @brief The HashTableEnumerator function type.
  * @param table The HashTable.
  * @param key The key.
@@ -125,12 +120,12 @@ struct HashTable {
   /**
    * @brief Optional destructor called when a key is removed or replaced.
    */
-  HashTableDestroyFunc destroyKey;
+  Consumer destroyKey;
 
   /**
    * @brief Optional destructor called when a value is removed or replaced.
    */
-  HashTableDestroyFunc destroyValue;
+  Consumer destroyValue;
 };
 
 /**

--- a/Sources/Objectively/List.h
+++ b/Sources/Objectively/List.h
@@ -35,11 +35,6 @@ typedef struct ListInterface ListInterface;
 typedef struct ListNode ListNode;
 
 /**
- * @brief A function called to destroy a list element on removal.
- */
-typedef void (*ListDestroyFunc)(ident obj);
-
-/**
  * @brief The ListEnumerator function type.
  * @param list The List.
  * @param node The current node.
@@ -93,7 +88,7 @@ struct List {
   /**
    * @brief Optional destructor called when an element is removed.
    */
-  ListDestroyFunc destroy;
+  Consumer destroy;
 };
 
 /**

--- a/Sources/Objectively/Vector.c
+++ b/Sources/Objectively/Vector.c
@@ -51,6 +51,7 @@ static Object *copy(const Object *self) {
   memcpy(that->elements, this->elements, this->count * this->size);
   that->count = this->count;
   that->capacity = this->capacity;
+  that->destroy = this->destroy;
 
   return (Object *) that;
 }
@@ -61,6 +62,8 @@ static Object *copy(const Object *self) {
 static void dealloc(Object *self) {
 
   Vector *this = (Vector *) self;
+
+  $(this, removeAllElements);
 
   free(this->elements);
 
@@ -271,6 +274,13 @@ static ident reduce(const Vector *self, Reducer reducer, ident accumulator, iden
  * @memberof Vector
  */
 static void removeAllElements(Vector *self) {
+
+  if (self->destroy) {
+    for (size_t i = 0; i < self->count; i++) {
+      self->destroy(self->elements + i * self->size);
+    }
+  }
+
   self->count = 0;
 }
 
@@ -281,6 +291,10 @@ static void removeAllElements(Vector *self) {
 static void removeElementAtIndex(Vector *self, size_t index) {
 
   assert(index < self->count);
+
+  if (self->destroy) {
+    self->destroy(self->elements + index * self->size);
+  }
 
   const size_t size = (self->count - index) * self->size;
 
@@ -294,6 +308,12 @@ static void removeElementAtIndex(Vector *self, size_t index) {
  * @memberof Vector
  */
 static void resize(Vector *self, size_t capacity) {
+
+  if (self->destroy) {
+    for (size_t i = capacity; i < self->count; i++) {
+      self->destroy(self->elements + i * self->size);
+    }
+  }
 
   self->elements = realloc(self->elements, capacity * self->size);
   assert(self->elements);

--- a/Sources/Objectively/Vector.h
+++ b/Sources/Objectively/Vector.h
@@ -80,6 +80,11 @@ struct Vector {
    * @brief The elements.
    */
   ident elements;
+
+  /**
+   * @brief Optional destructor called when an element is removed.
+   */
+  Consumer destroy;
 };
 
 /**

--- a/Tests/Objectively/Vector.c
+++ b/Tests/Objectively/Vector.c
@@ -52,6 +52,35 @@ START_TEST(addElement) {
 
 } END_TEST
 
+static int destroyCount;
+
+static void destroyFunc(ident element) {
+  destroyCount++;
+}
+
+START_TEST(destroy) {
+
+  destroyCount = 0;
+
+  Vector *vector = $(alloc(Vector), initWithSize, sizeof(Foo));
+  vector->destroy = destroyFunc;
+
+  Foo one = { 1 }, two = { 2 }, three = { 3 };
+
+  $(vector, addElement, &one);
+  $(vector, addElement, &two);
+  $(vector, addElement, &three);
+
+  $(vector, removeElementAtIndex, 0);
+  ck_assert_int_eq(1, destroyCount);
+
+  $(vector, removeAllElements);
+  ck_assert_int_eq(3, destroyCount);
+
+  release(vector);
+
+} END_TEST
+
 static void enumerator(const Vector *vector, ident element, ident data) {
   *(int *) data += *(int *) element;
 }
@@ -319,6 +348,7 @@ int main(int argc, char **argv) {
 
   TCase *tcase = tcase_create("Vector");
   tcase_add_test(tcase, addElement);
+  tcase_add_test(tcase, destroy);
   tcase_add_test(tcase, enumerate);
   tcase_add_test(tcase, filter);
   tcase_add_test(tcase, find);


### PR DESCRIPTION
Three collection types (`List`, `HashTable`, `Vector`) each had their own bespoke `void (*)(ident)` typedef for element destruction. `List` had `ListDestroyFunc`, `HashTable` had `HashTableDestroyFunc`, and `Vector` had none at all. All three are identical in signature to the existing `Consumer` type in `Types.h`, so this PR unifies them and adds the missing feature to `Vector`.

**What changed:**

- `ListDestroyFunc` and `HashTableDestroyFunc` are removed; their `destroy`/`destroyKey`/`destroyValue` fields are now typed as `Consumer`.
- `Vector` gains a `Consumer destroy` field, consistent with `List`.
- `Vector::dealloc` now calls `removeAllElements` before `free` so the destructor fires on release.
- `Vector::removeAllElements`, `removeElementAtIndex`, and `resize` each invoke `destroy` when set (resize calls it for any elements truncated by a shrink).
- `Vector::copy` propagates `destroy` to the new instance.
- A `destroy` test case is added to the Vector test suite.