### PR TITLE
HashTable: auto-resize on load factor 0.75

### DIFF
--- a/Sources/Objectively/HashTable.c
+++ b/Sources/Objectively/HashTable.c
@@ -34,6 +34,8 @@
 #define _Class _HashTable
 
 #define HASHTABLE_DEFAULT_CAPACITY 16
+#define HASHTABLE_GROW_FACTOR 2
+#define HASHTABLE_MAX_LOAD 0.75f
 
 #pragma mark - Built-in hash/equal functions
 
@@ -244,10 +246,37 @@ static void removeAll(HashTable *self) {
 }
 
 /**
+ * @brief Rehashes all entries into a new bucket array of the given capacity.
+ */
+static void resize(HashTable *self, size_t capacity) {
+
+  HashTableEntry **buckets = calloc(capacity, sizeof(HashTableEntry *));
+  assert(buckets);
+
+  for (size_t i = 0; i < self->capacity; i++) {
+    for (HashTableEntry *e = self->buckets[i]; e; ) {
+      HashTableEntry *next = e->next;
+      const size_t bin = self->hash(e->key) % capacity;
+      e->next = buckets[bin];
+      buckets[bin] = e;
+      e = next;
+    }
+  }
+
+  free(self->buckets);
+  self->buckets = buckets;
+  self->capacity = capacity;
+}
+
+/**
  * @fn void HashTable::set(HashTable *self, const ident key, const ident value)
  * @memberof HashTable
  */
 static void set(HashTable *self, const ident key, const ident value) {
+
+  if ((float) self->count / (float) self->capacity >= HASHTABLE_MAX_LOAD) {
+    resize(self, self->capacity * HASHTABLE_GROW_FACTOR);
+  }
 
   const size_t bin = self->hash(key) % self->capacity;
 

--- a/Tests/Objectively/HashTable.c
+++ b/Tests/Objectively/HashTable.c
@@ -22,6 +22,8 @@
  */
 
 #include <check.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 #include "Objectively.h"
 
@@ -155,6 +157,31 @@ START_TEST(set_replaces) {
 
 } END_TEST
 
+START_TEST(set_resizes) {
+
+  HashTable *table = $(alloc(HashTable), init, HashTableHashStr, HashTableEqualStr);
+
+  ck_assert_int_eq(16, table->capacity);
+
+  enum { N = 100000 };
+  char (*keys)[16] = malloc(N * sizeof(*keys));
+  for (int i = 0; i < N; i++) {
+    snprintf(keys[i], sizeof(*keys), "%d", i);
+    $(table, set, keys[i], keys[i]);
+  }
+
+  ck_assert_int_eq(N, table->count);
+  ck_assert(table->capacity > 16);
+
+  for (int i = 0; i < N; i++) {
+    ck_assert_str_eq(keys[i], $(table, get, keys[i]));
+  }
+
+  free(keys);
+  release(table);
+
+} END_TEST
+
 START_TEST(hash_direct) {
 
   int a = 1, b = 2;
@@ -183,6 +210,7 @@ int main(int argc, char **argv) {
   tcase_add_test(tcase, removeEntry);
   tcase_add_test(tcase, removeAll);
   tcase_add_test(tcase, set_replaces);
+  tcase_add_test(tcase, set_resizes);
   tcase_add_test(tcase, hash_direct);
 
   Suite *suite = suite_create("HashTable");


### PR DESCRIPTION
## Problem

`HashTable` was created with a fixed 16-bucket array and never resized. As entries accumulated, every bucket became a linked list of length ~N/16, turning every `get`/`set` into an O(N) chain walk. In Quemap's welding loop — 27 lookups per vertex across a large terrain map — this compounded into an effectively O(V·N) quadratic blowup, adding ~100 seconds to BSP emit time.

`Dictionary` already had auto-resize with a 0.75 load factor. `HashTable` simply lacked it.

## Fix

Add a `resize()` helper that rehashes all existing entries into a new bucket array, and call it from `set()` whenever `count / capacity >= 0.75`, doubling capacity each time. No public API changes.

```c
static void resize(HashTable *self, size_t capacity) {
    HashTableEntry **buckets = calloc(capacity, sizeof(HashTableEntry *));
    for (size_t i = 0; i < self->capacity; i++) {
        for (HashTableEntry *e = self->buckets[i]; e; ) {
            HashTableEntry *next = e->next;
            const size_t bin = self->hash(e->key) % capacity;
            e->next = buckets[bin];
            buckets[bin] = e;
            e = next;
        }
    }
    free(self->buckets);
    self->buckets = buckets;
    self->capacity = capacity;
}
```

## Test

The `set_resizes` test uses 100k entries, driving ~13 resize doublings (16 → 131072+) and verifying every key is still reachable after all rehash rounds.